### PR TITLE
lm4f: Update makefile for "make flash" support

### DIFF
--- a/examples/lm4f/Makefile.include
+++ b/examples/lm4f/Makefile.include
@@ -51,12 +51,9 @@ LDFLAGS         += --static -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group 
 
 OBJS		+= $(BINARY).o
 
-# Support for ICDI is not in any openocd release as of yet
-# A patch to add support for ICDI is under review
+# Support for ICDI is available starting with openocd 0.7.0
 OOCD		?= openocd
-OOCD_INTERFACE	?= ti-icdi
-# No official board.cfg for the stellaris launchpad
-OOCD_BOARD	?= stellaris_launchpad
+OOCD_BOARD	?= ek-lm4f120xl
 
 # Be silent per default, but 'make V=1' will show all compiler calls.
 ifneq ($(V),1)
@@ -112,30 +109,14 @@ clean:
 	$(Q)rm -f *.list
 
 # FIXME: Replace STM32 stuff with proper Stellaris support.
-ifeq ($(OOCD_SERIAL),)
 %.flash: %.hex
 	@printf "  FLASH   $<\n"
 	@# IMPORTANT: Don't use "resume", only "reset" will work correctly!
-	$(Q)$(OOCD) -f interface/$(OOCD_INTERFACE).cfg \
-		    -f board/$(OOCD_BOARD).cfg \
+	$(Q)$(OOCD) -f board/$(OOCD_BOARD).cfg \
 		    -c "init" -c "reset init" \
-		    -c "stm32x mass_erase 0" \
-		    -c "flash write_image $(*).hex" \
+		    -c "flash write_image erase $(*).hex 0" \
 		    -c "reset" \
 		    -c "shutdown" $(NULL)
-else
-%.flash: %.hex
-	@printf "  FLASH   $<\n"
-	@# IMPORTANT: Don't use "resume", only "reset" will work correctly!
-	$(Q)$(OOCD) -f interface/$(OOCD_INTERFACE).cfg \
-		    -f board/$(OOCD_BOARD).cfg \
-		    -c "ft2232_serial $(OOCD_SERIAL)" \
-		    -c "init" -c "reset init" \
-		    -c "stm32x mass_erase 0" \
-		    -c "flash write_image $(*).hex" \
-		    -c "reset" \
-		    -c "shutdown" $(NULL)
-endif
 
 .PHONY: images clean
 


### PR DESCRIPTION
When the makefile was originally written, openocd did not officially
support ICDI. Now that ICDI support is part of an official openocd release,
update the makefile to enable flashing with "make flash".
