### PR TITLE
lm4f: Update examples to the new GPIO API

### DIFF
--- a/examples/lm4f/stellaris-ek-lm4f120xl/uart_echo_interrupt/uart_echo_interrupt.c
+++ b/examples/lm4f/stellaris-ek-lm4f120xl/uart_echo_interrupt/uart_echo_interrupt.c
@@ -25,14 +25,10 @@
 
 static void uart_setup(void)
 {
-	u32 pins;
 	/* Enable GPIOA in run mode. */
 	periph_clock_enable(RCC_GPIOA);
-	/* Configure PA0 and PA1 as alternate function pins */
-	pins = GPIO0 | GPIO1;
-	GPIO_AFSEL(GPIOA) |= pins;
-	GPIO_DEN(GPIOA) |= pins;
-	/* PA0 and PA1 are muxed to UART0 during power on, by default */
+	/* Mux PA0 and PA1 to UART0 (alternate function 1) */
+	gpio_set_af(GPIOA, 1, GPIO0 | GPIO1);
 
 	/* Enable the UART clock */
 	periph_clock_enable(RCC_UART0);
@@ -79,6 +75,7 @@ void uart0_isr(void)
 
 int main(void)
 {
+	gpio_enable_ahb_aperture();
 	uart_setup();
 	uart_irq_setup();
 

--- a/examples/lm4f/stellaris-ek-lm4f120xl/uart_echo_simple/uart_echo_simple.c
+++ b/examples/lm4f/stellaris-ek-lm4f120xl/uart_echo_simple/uart_echo_simple.c
@@ -24,14 +24,10 @@
 
 static void uart_setup(void)
 {
-	u32 pins;
 	/* Enable GPIOA in run mode. */
 	periph_clock_enable(RCC_GPIOA);
-	/* Configure PA0 and PA1 as alternate function pins */
-	pins = GPIO0 | GPIO1;
-	GPIO_AFSEL(GPIOA) |= pins;
-	GPIO_DEN(GPIOA) |= pins;
-	/* PA0 and PA1 are muxed to UART0 during power on, by default */
+	/* Mux PA0 and PA1 to UART0 (alternate function 1) */
+	gpio_set_af(GPIOA, 1, GPIO0 | GPIO1);
 
 	/* Enable the UART clock */
 	periph_clock_enable(RCC_UART0);
@@ -54,7 +50,8 @@ static void uart_setup(void)
 int main(void)
 {
 	u8 rx;
-	
+
+	gpio_enable_ahb_aperture();
 	uart_setup();
 
 	/*


### PR DESCRIPTION
We updated the GPIO API to use the AHB bus; however the AHP aperture for
GPIO ports A through J needs to be explicitly enabled at runtime. Accessing
the AHB aperture otherwise hardfaults.

To make the examples work again, we call gpio_enable_ahb_aperture() at the
start of main().

Since we're at it, we also take out the ugly register accesses in favor
of the new gpio functions.

Signed-off-by: Alexandru Gagniuc mr.nuke.me@gmail.com
