### PR TITLE
hse pll was configured to the wrong crystal

### DIFF
--- a/examples/stm32/f1/stm32-h107/fancyblink/fancyblink.c
+++ b/examples/stm32/f1/stm32-h107/fancyblink/fancyblink.c
@@ -24,7 +24,7 @@
 /* Set STM32 to 72 MHz. */
 static void clock_setup(void)
 {
-	rcc_clock_setup_in_hse_8mhz_out_72mhz();
+	rcc_clock_setup_in_hse_25mhz_out_72mhz();
 
 	/* Enable GPIOC clock. */
 	rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN);

--- a/examples/stm32/f1/stm32-h107/usb_simple/usb_simple.c
+++ b/examples/stm32/f1/stm32-h107/usb_simple/usb_simple.c
@@ -100,7 +100,7 @@ int main(void)
 {
 	usbd_device *usbd_dev;
 
-	rcc_clock_setup_in_hse_8mhz_out_72mhz();
+	rcc_clock_setup_in_hse_25mhz_out_72mhz();
 
 	rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPAEN);
 	rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN);


### PR DESCRIPTION
The usb example was tested on the OLIMEX STM32-H107 board. It now works again.
So does the fancy blink example.
