### PR TITLE
LED blinker using Systick demo

### DIFF
--- a/examples/stm32/f4/stm32f4-discovery/tick_blink/Makefile
+++ b/examples/stm32/f4/stm32f4-discovery/tick_blink/Makefile
@@ -1,0 +1,25 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = tick_blink
+
+LDSCRIPT = ../stm32f4-discovery.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f4/stm32f4-discovery/tick_blink/README
+++ b/examples/stm32/f4/stm32f4-discovery/tick_blink/README
@@ -1,0 +1,8 @@
+README
+------
+
+This example is the same as fancy_blink except that it uses the
+systick timer to generate time accurate delays. Shows how to set
+up the systick timer to create an interrupt every millisecond and
+how to write a delay routine (msleep) that can then delay for a
+specific number of milliseconds.

--- a/examples/stm32/f4/stm32f4-discovery/tick_blink/tick_blink.c
+++ b/examples/stm32/f4/stm32f4-discovery/tick_blink/tick_blink.c
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Damjan Marion <damjan.marion@gmail.com>
+ * Copyright (C) 2011 Mark Panajotovic <marko@electrontube.org>
+ * Copyright (C) 2013 Chuck McManis <cmcmanis@mcmanis.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* This version derived from fancy blink */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/cm3/systick.h>
+
+void msleep(uint32_t);
+
+/* monotonically increasing number of milliseconds from reset
+ * overflows every 49 days if you're wondering
+ */
+volatile uint32_t system_millis;
+
+/* Called when systick fires */
+void sys_tick_handler(void) {
+	system_millis++;
+}
+
+/* sleep for delay milliseconds */
+void msleep(uint32_t delay) {
+	uint32_t wake = system_millis + delay;
+	while (wake > system_millis) ;
+}
+
+/* Set up a timer to create 1mS ticks. */
+static void systick_setup(void)
+{
+	/* clock rate / 1000 to get 1mS interrupt rate */
+	systick_set_reload(168000);
+	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB);
+	systick_counter_enable();
+	/* this done last */
+	systick_interrupt_enable();
+}
+
+/* Set STM32 to 168 MHz. */
+static void clock_setup(void)
+{
+	rcc_clock_setup_hse_3v3(&hse_8mhz_3v3[CLOCK_3V3_168MHZ]);
+
+	/* Enable GPIOD clock. */
+	rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPDEN);
+}
+
+static void gpio_setup(void)
+{
+	/* Set GPIO11-15 (in GPIO port D) to 'output push-pull'. */
+	gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT,
+			GPIO_PUPD_NONE, GPIO11 | GPIO12 | GPIO13 | GPIO14 | GPIO15);
+}
+
+int main(void)
+{
+	clock_setup();
+	gpio_setup();
+	systick_setup();
+
+	/* Set two LEDs for wigwag effect when toggling. */
+	gpio_set(GPIOD, GPIO12 | GPIO14);
+
+	/* Blink the LEDs (PD12, PD13, PD14 and PD15) on the board. */
+	while (1) {
+		gpio_toggle(GPIOD, GPIO12 | GPIO13 | GPIO14 | GPIO15);
+		msleep(100);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This is a variant on fancy_blink that uses the Systick timer for time accurate delays. Mostly its
a way to show how to set up the systick timer as a system millisecond counter.
