### PR TITLE
lm3s: add LM3S811 eval board miniblink example

### DIFF
--- a/examples/lm3s/lm3s811-evb/lm3s811-evb.ld
+++ b/examples/lm3s/lm3s811-evb/lm3s811-evb.ld
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2010 Uwe Hermann <uwe@hermann-uwe.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for Luminary Micro (now TI) Stellaris LM3S811-EVB. */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x00000000, LENGTH = 64K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 8K
+}
+
+/* Include the common ld script. */
+INCLUDE libopencm3_lm3s.ld
+

--- a/examples/lm3s/lm3s811-evb/miniblink/Makefile
+++ b/examples/lm3s/lm3s811-evb/miniblink/Makefile
@@ -1,0 +1,25 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2010 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = miniblink
+
+LDSCRIPT = ../lm3s811-evb.ld
+
+include ../../Makefile.include
+

--- a/examples/lm3s/lm3s811-evb/miniblink/README
+++ b/examples/lm3s/lm3s811-evb/miniblink/README
@@ -1,0 +1,9 @@
+------------------------------------------------------------------------------
+README
+------------------------------------------------------------------------------
+
+This is the smallest-possible example program using libopencm3.
+
+It's intended for the LuminaryMicro LM3S811-EVB.
+It should blink the STATUS LED on the board.
+

--- a/examples/lm3s/lm3s811-evb/miniblink/miniblink.c
+++ b/examples/lm3s/lm3s811-evb/miniblink/miniblink.c
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2011 Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/lm3s/systemcontrol.h>
+#include <libopencm3/lm3s/gpio.h>
+
+static void gpio_setup(void)
+{
+	SYSTEMCONTROL_RCGC2 |= 0x04; /* Enable GPIOC in run mode. */
+
+	GPIO_DIR(GPIOC) |= (1 << 5); /* Configure PC5 as output. */
+	GPIO_DEN(GPIOC) |= (1 << 5); /* Enable digital function on PC5. */
+}
+
+int main(void)
+{
+	int i;
+
+	gpio_setup();
+
+	/* Blink STATUS LED (PC5) on the board. */
+	while (1) {
+		gpio_set(GPIOC, GPIO5);
+
+		for (i = 0; i < 800000; i++)	/* Wait a bit. */
+			__asm__("nop");
+
+		gpio_clear(GPIOC, GPIO5);
+
+		for (i = 0; i < 800000; i++)	/* Wait a bit. */
+			__asm__("nop");
+	}
+
+	return 0;
+}


### PR DESCRIPTION
The LM3S811-EVB miniblink example is a copy of the LM3S3748-EVB miniblink
example.  Modifications:
- rename lm3s3748-evb.ld to lm3s811-evb.ld and change RAM and ROM sizes
- amend Makefile to reference the lm3s811-evb.ld linker script
- amend miniblink.c to use PC5 instead of PF0 for the LED GPIO
- amend README to reference LM3S811-EVB instead of LM3S3748-EVB
