### PR TITLE
Make the STM32 Makefile.includes usable from outside the examples tree

### DIFF
--- a/examples/stm32/f1/Makefile.include
+++ b/examples/stm32/f1/Makefile.include
@@ -27,7 +27,7 @@ OBJDUMP		= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
 TOOLCHAIN_DIR ?= ../../../../../libopencm3
-ifeq ($(wildcard ../../../../../libopencm3/lib/libopencm3_stm32f1.a),)
+ifeq ($(wildcard $(TOOLCHAIN_DIR)/lib/libopencm3_stm32f1.a),)
 ifneq ($(strip $(shell which $(CC))),)
 TOOLCHAIN_DIR := $(shell dirname `which $(CC)`)/../$(PREFIX)
 endif

--- a/examples/stm32/f2/Makefile.include
+++ b/examples/stm32/f2/Makefile.include
@@ -28,7 +28,7 @@ OBJDUMP		= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
 TOOLCHAIN_DIR ?= ../../../../../libopencm3
-ifeq ($(wildcard ../../../../../libopencm3/lib/libopencm3_stm32f2.a),)
+ifeq ($(wildcard $(TOOLCHAIN_DIR)/lib/libopencm3_stm32f2.a),)
 ifneq ($(strip $(shell which $(CC))),)
 TOOLCHAIN_DIR := $(shell dirname `which $(CC)`)/../$(PREFIX)
 endif

--- a/examples/stm32/f3/Makefile.include
+++ b/examples/stm32/f3/Makefile.include
@@ -29,7 +29,7 @@ GDB		= $(PREFIX)-gdb
 FLASH		= $(shell which st-flash)
 
 TOOLCHAIN_DIR ?= ../../../../../libopencm3
-ifeq ($(wildcard ../../../../../libopencm3/lib/libopencm3_stm32f3.a),)
+ifeq ($(wildcard $(TOOLCHAIN_DIR)/lib/libopencm3_stm32f3.a),)
 ifneq ($(strip $(shell which $(CC))),)
 TOOLCHAIN_DIR := $(shell dirname `which $(CC)`)/../$(PREFIX)
 endif

--- a/examples/stm32/f4/Makefile.include
+++ b/examples/stm32/f4/Makefile.include
@@ -29,7 +29,7 @@ GDB		= $(PREFIX)-gdb
 FLASH		= $(shell which st-flash)
 
 TOOLCHAIN_DIR ?= ../../../../../libopencm3
-ifeq ($(wildcard ../../../../../libopencm3/lib/libopencm3_stm32f4.a),)
+ifeq ($(wildcard $(TOOLCHAIN_DIR)/lib/libopencm3_stm32f4.a),)
 ifneq ($(strip $(shell which $(CC))),)
 TOOLCHAIN_DIR := $(shell dirname `which $(CC)`)/../$(PREFIX)
 endif


### PR DESCRIPTION
The Makefile.includes contain a hardcoded ../../../../../libopencm3
path for the TOOLCHAIN_DIR variable. They also contained another copy
of this hardcoded path, that is now generated from $TOOLCHAIN_DIR.

This allows to have a symbolic link to a Makefile.include in an
out-of-tree project and reuse the Makefile infrastructure.
