### PR TITLE
Correct the F3 examples hardfaults in rare cases, correct style

### DIFF
--- a/examples/stm32/f3/stm32f3-discovery/adc/adc.c
+++ b/examples/stm32/f3/stm32f3-discovery/adc/adc.c
@@ -21,7 +21,7 @@
  */
 
 #include <libopencm3/stm32/rcc.h>
-#include <libopencm3/stm32/f3/adc.h>
+#include <libopencm3/stm32/adc.h>
 #include <libopencm3/stm32/usart.h>
 #include <libopencm3/stm32/gpio.h>
 
@@ -44,7 +44,8 @@
 #define LD6 GPIOE, GPIO15
 
 
-void adc_setup(void) {
+static void adc_setup(void)
+{
 	//ADC
 	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_ADC12EN);
 	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
@@ -53,91 +54,93 @@ void adc_setup(void) {
 	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO1);
 	adc_off(ADC1);
 	adc_set_clk_prescale(ADC_CCR_CKMODE_DIV2);
-        adc_set_single_conversion_mode(ADC1);
-        adc_disable_external_trigger_regular(ADC1);
-        adc_set_right_aligned(ADC1);
-        /* We want to read the temperature sensor, so we have to enable it. */
-        adc_enable_temperature_sensor();
-        adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR1_SMP_61DOT5CYC);
+	adc_set_single_conversion_mode(ADC1);
+	adc_disable_external_trigger_regular(ADC1);
+	adc_set_right_aligned(ADC1);
+	/* We want to read the temperature sensor, so we have to enable it. */
+	adc_enable_temperature_sensor();
+	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR1_SMP_61DOT5CYC);
 	uint8_t channel_array[16];
 	channel_array[0]=16; // Vts (Internal temperature sensor
 	channel_array[0]=1; //ADC1_IN1 (PA0)
 	adc_set_regular_sequence(ADC1, 1, channel_array);
 	adc_set_resolution(ADC1, ADC_CFGR_RES_12_BIT);
-        adc_power_on(ADC1);
+	adc_power_on(ADC1);
 
-        /* Wait for ADC starting up. */
+	/* Wait for ADC starting up. */
 	int i;
-        for (i = 0; i < 800000; i++)    /* Wait a bit. */
-                __asm__("nop");
+	for (i = 0; i < 800000; i++)
+		__asm__("nop");
 
 }
 
-void usart_setup(void) {
-  /* Enable clocks for GPIO port A (for GPIO_USART2_TX) and USART2. */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USART2EN);
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
+static void usart_setup(void)
+{
+	/* Enable clocks for GPIO port A (for GPIO_USART2_TX) and USART2. */
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USART2EN);
+	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
 
-  /* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
-  gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2 | GPIO3);
-  gpio_set_af(GPIOA, GPIO_AF7, GPIO2| GPIO3);
+	/* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2 | GPIO3);
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2| GPIO3);
 
-  /* Setup UART parameters. */
-  usart_set_baudrate(USART2, 115200);
-  usart_set_databits(USART2, 8);
-  usart_set_stopbits(USART2, USART_STOPBITS_1);
-  usart_set_mode(USART2, USART_MODE_TX_RX);
-  usart_set_parity(USART2, USART_PARITY_NONE);
-  usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
+	/* Setup UART parameters. */
+	usart_set_baudrate(USART2, 115200);
+	usart_set_databits(USART2, 8);
+	usart_set_stopbits(USART2, USART_STOPBITS_1);
+	usart_set_mode(USART2, USART_MODE_TX_RX);
+	usart_set_parity(USART2, USART_PARITY_NONE);
+	usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
 
-  /* Finally enable the USART. */
-  usart_enable(USART2);
+	/* Finally enable the USART. */
+	usart_enable(USART2);
 }
 
-void gpio_setup(void)
+static void gpio_setup(void)
 {
 	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPEEN);
-	gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO8| GPIO9| GPIO10| GPIO11| GPIO12| GPIO13| GPIO14| GPIO15);
+	gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE,
+		GPIO8 | GPIO9 | GPIO10 | GPIO11 | GPIO12 | GPIO13 |
+		GPIO14 | GPIO15);
 }
 
-void my_usart_print_int(uint32_t usart, int16_t value)
+static void my_usart_print_int(uint32_t usart, int16_t value)
 {
-        int8_t i;
-        int8_t nr_digits = 0;
-        char buffer[25];
+	int8_t i;
+	int8_t nr_digits = 0;
+	char buffer[25];
 
-        if (value < 0) {
-                usart_send_blocking(usart, '-');
-                value = value * -1;
-        }
+	if (value < 0) {
+		usart_send_blocking(usart, '-');
+		value = value * -1;
+	}
 
-        if (value == 0) {
-                usart_send_blocking(usart, '0');
-        }
+	if (value == 0) {
+		usart_send_blocking(usart, '0');
+	}
 
-        while (value > 0) {
-                buffer[nr_digits++] = "0123456789"[value % 10];
-                value /= 10;
-        }
+	while (value > 0) {
+		buffer[nr_digits++] = "0123456789"[value % 10];
+		value /= 10;
+	}
 
-        for (i = nr_digits-1; i >= 0; i--) {
-                usart_send_blocking(usart, buffer[i]);
-        }
+	for (i = nr_digits-1; i >= 0; i--) {
+		usart_send_blocking(usart, buffer[i]);
+	}
 
-        usart_send_blocking(usart, '\r');
-        usart_send_blocking(usart, '\n');
+	usart_send_blocking(usart, '\r');
+	usart_send_blocking(usart, '\n');
 }
 
-void clock_setup(void) {
-  //rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_44MHZ]);
-  rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_64MHZ]);
+static void clock_setup(void)
+{
+	rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_64MHZ]);
 }
 
-extern unsigned _stack;
 
 int main(void)
 {
-       	uint16_t temp;
+	uint16_t temp;
 
 	clock_setup();
 	gpio_setup();
@@ -145,11 +148,11 @@ int main(void)
 	usart_setup();
 
 	while (1) {
-	  adc_start_conversion_regular(ADC1);
-	  while (!(adc_eoc(ADC1)));
-	  temp=adc_read_regular(ADC1);
- 	  gpio_port_write(GPIOE, temp << 4);
-	  my_usart_print_int(USART2, temp);
+		adc_start_conversion_regular(ADC1);
+		while (!(adc_eoc(ADC1)));
+		temp=adc_read_regular(ADC1);
+ 		gpio_port_write(GPIOE, temp << 4);
+		my_usart_print_int(USART2, temp);
 	}
 
 	return 0;

--- a/examples/stm32/f3/stm32f3-discovery/button/button.c
+++ b/examples/stm32/f3/stm32f3-discovery/button/button.c
@@ -27,12 +27,12 @@
 uint16_t exti_line_state;
 
 /* Set STM32 to 64 MHz. */
-void clock_setup(void)
+static void clock_setup(void)
 {
 	rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_64MHZ]);
 }
 
-void gpio_setup(void)
+static void gpio_setup(void)
 {
 	/* Enable GPIOD clock. */
 	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPEEN);
@@ -42,7 +42,7 @@ void gpio_setup(void)
 			GPIO_PUPD_NONE, GPIO8 | GPIO9 | GPIO10 | GPIO11);
 }
 
-void button_setup(void)
+static void button_setup(void)
 {
 	/* Enable GPIOA clock. */
 	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);

--- a/examples/stm32/f3/stm32f3-discovery/fancyblink/fancyblink.c
+++ b/examples/stm32/f3/stm32f3-discovery/fancyblink/fancyblink.c
@@ -23,7 +23,7 @@
 #include <libopencm3/stm32/gpio.h>
 
 /* Set STM32 to 64 MHz. */
-void clock_setup(void)
+static void clock_setup(void)
 {
 	rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_64MHZ]);
 
@@ -31,7 +31,7 @@ void clock_setup(void)
 	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPEEN);
 }
 
-void gpio_setup(void)
+static void gpio_setup(void)
 {
 	/* Set GPIO8-11 (in GPIO port E) to 'output push-pull'. */
 	gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT,

--- a/examples/stm32/f3/stm32f3-discovery/i2c/i2c.c
+++ b/examples/stm32/f3/stm32f3-discovery/i2c/i2c.c
@@ -43,86 +43,91 @@
 #define LD8 GPIOE, GPIO14
 #define LD6 GPIOE, GPIO15
 
-void i2c_setup(void) {
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_I2C1EN);
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPBEN);
-  rcc_set_i2c_clock_hsi(I2C1);
+static void i2c_setup(void)
+{
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_I2C1EN);
+	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPBEN);
+	rcc_set_i2c_clock_hsi(I2C1);
 
-  i2c_reset(I2C1);
-  /* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
-  gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO6 | GPIO7);
-  gpio_set_af(GPIOB, GPIO_AF4, GPIO6| GPIO7);
-  i2c_peripheral_disable(I2C1);
-  //configure ANFOFF DNF[3:0] in CR1
-  i2c_enable_analog_filter(I2C1);
-  i2c_set_digital_filter(I2C1, I2C_CR1_DNF_DISABLED);
-  //Configure PRESC[3:0] SDADEL[3:0] SCLDEL[3:0]  SCLH[7:0] SCLL[7:0] in TIMINGR
-  i2c_100khz_i2cclk8mhz(I2C1);
-  //configure No-Stretch CR1 (only relevant in slave mode)
-  i2c_enable_stretching(I2C1);
-  //addressing mode
-  i2c_set_7bit_addr_mode(I2C1);
-  i2c_peripheral_enable(I2C1);
+	i2c_reset(I2C1);
+	/* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
+	gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO6 | GPIO7);
+	gpio_set_af(GPIOB, GPIO_AF4, GPIO6| GPIO7);
+	i2c_peripheral_disable(I2C1);
+	//configure ANFOFF DNF[3:0] in CR1
+	i2c_enable_analog_filter(I2C1);
+	i2c_set_digital_filter(I2C1, I2C_CR1_DNF_DISABLED);
+	//Configure PRESC[3:0] SDADEL[3:0] SCLDEL[3:0] SCLH[7:0] SCLL[7:0]
+	// in TIMINGR
+	i2c_100khz_i2cclk8mhz(I2C1);
+	//configure No-Stretch CR1 (only relevant in slave mode)
+	i2c_enable_stretching(I2C1);
+	//addressing mode
+	i2c_set_7bit_addr_mode(I2C1);
+	i2c_peripheral_enable(I2C1);
 }
 
-void usart_setup(void) {
-  /* Enable clocks for GPIO port A (for GPIO_USART2_TX) and USART2. */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USART2EN);
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
+static void usart_setup(void)
+{
+	/* Enable clocks for GPIO port A (for GPIO_USART2_TX) and USART2. */
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USART2EN);
+	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
 
-  /* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
-  gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2 | GPIO3);
-  gpio_set_af(GPIOA, GPIO_AF7, GPIO2| GPIO3);
+	/* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2 | GPIO3);
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2| GPIO3);
 
-  /* Setup UART parameters. */
-  usart_set_baudrate(USART2, 115200);
-  usart_set_databits(USART2, 8);
-  usart_set_stopbits(USART2, USART_STOPBITS_1);
-  usart_set_mode(USART2, USART_MODE_TX_RX);
-  usart_set_parity(USART2, USART_PARITY_NONE);
-  usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
+	/* Setup UART parameters. */
+	usart_set_baudrate(USART2, 115200);
+	usart_set_databits(USART2, 8);
+	usart_set_stopbits(USART2, USART_STOPBITS_1);
+	usart_set_mode(USART2, USART_MODE_TX_RX);
+	usart_set_parity(USART2, USART_PARITY_NONE);
+	usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
 
-  /* Finally enable the USART. */
-  usart_enable(USART2);
+	/* Finally enable the USART. */
+	usart_enable(USART2);
 }
 
-void gpio_setup(void)
+static void gpio_setup(void)
 {
 	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPEEN);
-	gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO8| GPIO9| GPIO10| GPIO11| GPIO12| GPIO13| GPIO14| GPIO15);
+	gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE,
+		GPIO8 | GPIO9 | GPIO10 | GPIO11 | GPIO12 | GPIO13 |
+		GPIO14 | GPIO15);
 }
 
-void my_usart_print_int(uint32_t usart, int32_t value)
+static void my_usart_print_int(uint32_t usart, int32_t value)
 {
-        int8_t i;
-        int8_t nr_digits = 0;
-        char buffer[25];
+	int8_t i;
+	int8_t nr_digits = 0;
+	char buffer[25];
 
-        if (value < 0) {
-                usart_send_blocking(usart, '-');
-                value = value * -1;
-        }
+	if (value < 0) {
+		usart_send_blocking(usart, '-');
+		value = value * -1;
+	}
 
-        if (value == 0) {
-                usart_send_blocking(usart, '0');
-        }
+	if (value == 0) {
+		usart_send_blocking(usart, '0');
+	}
 
-        while (value > 0) {
-                buffer[nr_digits++] = "0123456789"[value % 10];
-                value /= 10;
-        }
+	while (value > 0) {
+		buffer[nr_digits++] = "0123456789"[value % 10];
+		value /= 10;
+	}
 
-        for (i = nr_digits-1; i >= 0; i--) {
-                usart_send_blocking(usart, buffer[i]);
-        }
+	for (i = nr_digits-1; i >= 0; i--) {
+		usart_send_blocking(usart, buffer[i]);
+	}
 
-        usart_send_blocking(usart, '\r');
-        usart_send_blocking(usart, '\n');
+	usart_send_blocking(usart, '\r');
+	usart_send_blocking(usart, '\n');
 }
 
-void clock_setup(void) {
-  /*rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_44MHZ]);*/
-  rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_64MHZ]);
+static void clock_setup(void)
+{
+	rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_64MHZ]);
 }
 
 #define I2C_ACC_ADDR 0x19
@@ -155,16 +160,16 @@ int main(void)
 
 	while (1) {
 
-	  read_i2c(I2C1, I2C_ACC_ADDR, ACC_STATUS, 1, data);
-	  /*my_usart_print_int(USART2, data[0]);*/
-	  read_i2c(I2C1, I2C_ACC_ADDR, ACC_OUT_X_L_A, 1, data);
-	  acc_x=data[0];
-	  read_i2c(I2C1, I2C_ACC_ADDR, ACC_OUT_X_H_A, 1, data);
-	  acc_x|=(data[0] << 8);
-	  my_usart_print_int(USART2, (int16_t) acc_x);
-	  //int i;
-	  //for (i = 0; i < 800000; i++)    /* Wait a bit. */
-	  //  __asm__("nop");
+		read_i2c(I2C1, I2C_ACC_ADDR, ACC_STATUS, 1, data);
+		/*my_usart_print_int(USART2, data[0]);*/
+		read_i2c(I2C1, I2C_ACC_ADDR, ACC_OUT_X_L_A, 1, data);
+		acc_x=data[0];
+		read_i2c(I2C1, I2C_ACC_ADDR, ACC_OUT_X_H_A, 1, data);
+		acc_x|=(data[0] << 8);
+		my_usart_print_int(USART2, (int16_t) acc_x);
+		//int i;
+		//for (i = 0; i < 800000; i++)    /* Wait a bit. */
+		//  __asm__("nop");
 	}
 
 	return 0;

--- a/examples/stm32/f3/stm32f3-discovery/miniblink/miniblink.c
+++ b/examples/stm32/f3/stm32f3-discovery/miniblink/miniblink.c
@@ -23,46 +23,23 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 
-void gpio_setup(void)
+static void gpio_setup(void)
 {
 	/* Enable GPIOE clock. */
-	/* Manually: */
-	// RCC_AHB1ENR |= RCC_AHB1ENR_IOPDEN;
-	/* Using API functions: */
 	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPEEN);
 
 	/* Set GPIO12 (in GPIO port E) to 'output push-pull'. */
-	/* Manually: */
-	//GPIOE_CRH = (GPIO_CNF_OUTPUT_PUSHPULL << (((8 - 8) * 4) + 2));
-	//GPIOE_CRH |= (GPIO_MODE_OUTPUT_2_MHZ << ((8 - 8) * 4));
-	/* Using API functions: */
 	gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO12);
 }
 
 int main(void)
 {
-        int i;
+	int i;
 
 	gpio_setup();
 
 	/* Blink the LED (PC8) on the board. */
 	while (1) {
-		/* Manually: */
-		// GPIOD_BSRR = GPIO12;		/* LED off */
-		// for (i = 0; i < 1000000; i++)	/* Wait a bit. */
-		// 	__asm__("nop");
-		// GPIOD_BRR = GPIO9;		/* LED on */
-		// for (i = 0; i < 1000000; i++)	/* Wait a bit. */
-		// 	__asm__("nop");
-
-		/* Using API functions gpio_set()/gpio_clear(): */
-		//gpio_set(GPIOE, GPIO9);	/* LED off */
-		// for (i = 0; i < 1000000; i++)	/* Wait a bit. */
-		// 	__asm__("nop");
-		//gpio_clear(GPIOE, GPIO9);	/* LED on */
-		// for (i = 0; i < 1000000; i++)	/* Wait a bit. */
-		// 	__asm__("nop");
-
 		/* Using API function gpio_toggle(): */
 		gpio_toggle(GPIOE, GPIO12);	/* LED on/off */
 		for (i = 0; i < 2000000; i++) /* Wait a bit. */

--- a/examples/stm32/f3/stm32f3-discovery/spi/spi.c
+++ b/examples/stm32/f3/stm32f3-discovery/spi/spi.c
@@ -43,122 +43,124 @@
 #define LD8 GPIOE, GPIO14
 #define LD6 GPIOE, GPIO15
 
-void spi_setup(void) {
-  rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_SPI1EN);
-  /* For spi signal pins */
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
-  /* For spi mode select on the l3gd20 */
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPEEN);
+static void spi_setup(void)
+{
+	rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_SPI1EN);
+	/* For spi signal pins */
+	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
+	/* For spi mode select on the l3gd20 */
+	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPEEN);
 
-  /* Setup GPIOE3 pin for spi mode l3gd20 select. */
-  gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO3);
-  /* Start with spi communication disabled */
-  gpio_set(GPIOE, GPIO3);
+	/* Setup GPIOE3 pin for spi mode l3gd20 select. */
+	gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO3);
+	/* Start with spi communication disabled */
+	gpio_set(GPIOE, GPIO3);
 
-  /* Setup GPIO pins for AF5 for SPI1 signals. */
-  gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO5 | GPIO6 | GPIO7);
-  gpio_set_af(GPIOA, GPIO_AF5, GPIO5 | GPIO6 | GPIO7);
+	/* Setup GPIO pins for AF5 for SPI1 signals. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE,
+			GPIO5 | GPIO6 | GPIO7);
+	gpio_set_af(GPIOA, GPIO_AF5, GPIO5 | GPIO6 | GPIO7);
 
-  //spi initialization;
-  spi_set_master_mode(SPI1);
-  spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_64);
-  spi_set_clock_polarity_0(SPI1);
-  spi_set_clock_phase_0(SPI1);
-  spi_set_full_duplex_mode(SPI1);
-  spi_set_unidirectional_mode(SPI1); /* bidirectional but in 3-wire */
-  spi_set_data_size(SPI1, SPI_CR2_DS_8BIT);
-  spi_enable_software_slave_management(SPI1);
-  spi_send_msb_first(SPI1);
-  spi_set_nss_high(SPI1);
-  //spi_enable_ss_output(SPI1);
-  spi_fifo_reception_threshold_8bit(SPI1);
-  SPI_I2SCFGR(SPI1) &= ~SPI_I2SCFGR_I2SMOD;
-  spi_enable(SPI1);
+	//spi initialization;
+	spi_set_master_mode(SPI1);
+	spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_64);
+	spi_set_clock_polarity_0(SPI1);
+	spi_set_clock_phase_0(SPI1);
+	spi_set_full_duplex_mode(SPI1);
+	spi_set_unidirectional_mode(SPI1); /* bidirectional but in 3-wire */
+	spi_set_data_size(SPI1, SPI_CR2_DS_8BIT);
+	spi_enable_software_slave_management(SPI1);
+	spi_send_msb_first(SPI1);
+	spi_set_nss_high(SPI1);
+	//spi_enable_ss_output(SPI1);
+	spi_fifo_reception_threshold_8bit(SPI1);
+	SPI_I2SCFGR(SPI1) &= ~SPI_I2SCFGR_I2SMOD;
+	spi_enable(SPI1);
 }
 
-void usart_setup(void) {
-  /* Enable clocks for GPIO port A (for GPIO_USART2_TX) and USART2. */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USART2EN);
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
+static void usart_setup(void)
+{
+	/* Enable clocks for GPIO port A (for GPIO_USART2_TX) and USART2. */
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USART2EN);
+	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
 
-  /* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
-  gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2 | GPIO3);
-  gpio_set_af(GPIOA, GPIO_AF7, GPIO2| GPIO3);
+	/* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2 | GPIO3);
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2| GPIO3);
 
-  /* Setup UART parameters. */
-  usart_set_baudrate(USART2, 115200);
-  usart_set_databits(USART2, 8);
-  usart_set_stopbits(USART2, USART_STOPBITS_1);
-  usart_set_mode(USART2, USART_MODE_TX_RX);
-  usart_set_parity(USART2, USART_PARITY_NONE);
-  usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
+	/* Setup UART parameters. */
+	usart_set_baudrate(USART2, 115200);
+	usart_set_databits(USART2, 8);
+	usart_set_stopbits(USART2, USART_STOPBITS_1);
+	usart_set_mode(USART2, USART_MODE_TX_RX);
+	usart_set_parity(USART2, USART_PARITY_NONE);
+	usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
 
-  /* Finally enable the USART. */
-  usart_enable(USART2);
+	/* Finally enable the USART. */
+	usart_enable(USART2);
 }
 
-void gpio_setup(void)
+static void gpio_setup(void)
 {
 	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPEEN);
-	gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO8| GPIO9| GPIO10| GPIO11| GPIO12| GPIO13| GPIO14| GPIO15);
+	gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE,
+		GPIO8 | GPIO9 | GPIO10 | GPIO11 | GPIO12 | GPIO13 |
+		GPIO14 | GPIO15);
 }
 
-void my_usart_print_int(uint32_t usart, int32_t value)
+static void my_usart_print_int(uint32_t usart, int32_t value)
 {
-        int8_t i;
-        int8_t nr_digits = 0;
-        char buffer[25];
+	int8_t i;
+	int8_t nr_digits = 0;
+	char buffer[25];
 
-        if (value < 0) {
-                usart_send_blocking(usart, '-');
-                value = value * -1;
-        }
+	if (value < 0) {
+		usart_send_blocking(usart, '-');
+		value = value * -1;
+	}
 
-        if (value == 0) {
-                usart_send_blocking(usart, '0');
-        }
+	if (value == 0) {
+		usart_send_blocking(usart, '0');
+	}
 
-        while (value > 0) {
-                buffer[nr_digits++] = "0123456789"[value % 10];
-                value /= 10;
-        }
+	while (value > 0) {
+		buffer[nr_digits++] = "0123456789"[value % 10];
+		value /= 10;
+	}
 
-        for (i = nr_digits-1; i >= 0; i--) {
-                usart_send_blocking(usart, buffer[i]);
-        }
+	for (i = nr_digits-1; i >= 0; i--) {
+		usart_send_blocking(usart, buffer[i]);
+	}
 
-        usart_send_blocking(usart, '\r');
-        usart_send_blocking(usart, '\n');
+	usart_send_blocking(usart, '\r');
+	usart_send_blocking(usart, '\n');
 }
 
-void clock_setup(void) {
-  /*rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_44MHZ]);*/
-  rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_64MHZ]);
+static void clock_setup(void)
+{
+	rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_64MHZ]);
 }
 
-#define GYR_RNW (1 << 7) /* Write when zero */
-#define GYR_MNS (1 << 6) /* Multiple reads when 1 */
-#define GYR_WHO_AM_I 0x0F
-#define GYR_OUT_TEMP 0x26
-#define GYR_STATUS_REG 0x27
-#define GYR_CTRL_REG1 0x20
-#define GYR_CTRL_REG1_PD (1 << 3)
-#define GYR_CTRL_REG1_XEN (1 << 1)
-#define GYR_CTRL_REG1_YEN (1 << 0)
-#define GYR_CTRL_REG1_ZEN (1 << 2)
-#define GYR_CTRL_REG1_BW_SHIFT 4
-#define GYR_CTRL_REG4 0x23
-#define GYR_CTRL_REG4_FS_SHIFT 4
+#define GYR_RNW			(1 << 7) /* Write when zero */
+#define GYR_MNS			(1 << 6) /* Multiple reads when 1 */
+#define GYR_WHO_AM_I		0x0F
+#define GYR_OUT_TEMP		0x26
+#define GYR_STATUS_REG		0x27
+#define GYR_CTRL_REG1		0x20
+#define GYR_CTRL_REG1_PD	(1 << 3)
+#define GYR_CTRL_REG1_XEN	(1 << 1)
+#define GYR_CTRL_REG1_YEN	(1 << 0)
+#define GYR_CTRL_REG1_ZEN	(1 << 2)
+#define GYR_CTRL_REG1_BW_SHIFT	4
+#define GYR_CTRL_REG4		0x23
+#define GYR_CTRL_REG4_FS_SHIFT	4
 
-#define GYR_OUT_X_L 0x28
-#define GYR_OUT_X_H 0x29
-
-//      gpio_port_write(GPIOE, (I2C_ISR(i2c) & 0xFF) << 8);
-//      my_usart_print_int(USART2, (I2C_ISR(i2c) & 0xFF));
+#define GYR_OUT_X_L		0x28
+#define GYR_OUT_X_H		0x29
 
 int main(void)
 {
-        uint8_t temp;
+	uint8_t temp;
 	int16_t gyr_x;
 	clock_setup();
 	gpio_setup();
@@ -168,7 +170,9 @@ int main(void)
 	gpio_clear(GPIOE, GPIO3);
 	spi_send8(SPI1, GYR_CTRL_REG1);
 	spi_read8(SPI1);
-	spi_send8(SPI1, GYR_CTRL_REG1_PD | GYR_CTRL_REG1_XEN | GYR_CTRL_REG1_YEN | GYR_CTRL_REG1_ZEN | (3 << GYR_CTRL_REG1_BW_SHIFT));
+	spi_send8(SPI1, GYR_CTRL_REG1_PD | GYR_CTRL_REG1_XEN |
+			GYR_CTRL_REG1_YEN | GYR_CTRL_REG1_ZEN |
+			(3 << GYR_CTRL_REG1_BW_SHIFT));
 	spi_read8(SPI1);
 	gpio_set(GPIOE, GPIO3);
 
@@ -181,48 +185,48 @@ int main(void)
 
 	while (1) {
 
-	  gpio_clear(GPIOE, GPIO3);
-	  spi_send8(SPI1, GYR_WHO_AM_I | GYR_RNW);
-	  spi_read8(SPI1);
-	  spi_send8(SPI1, 0);
-	  temp=spi_read8(SPI1);
-	  my_usart_print_int(USART2, (temp));
-	  gpio_set(GPIOE, GPIO3);
+		gpio_clear(GPIOE, GPIO3);
+		spi_send8(SPI1, GYR_WHO_AM_I | GYR_RNW);
+		spi_read8(SPI1);
+		spi_send8(SPI1, 0);
+		temp=spi_read8(SPI1);
+		my_usart_print_int(USART2, (temp));
+		gpio_set(GPIOE, GPIO3);
 
-	  gpio_clear(GPIOE, GPIO3);
-	  spi_send8(SPI1, GYR_STATUS_REG | GYR_RNW);
-	  spi_read8(SPI1);
-	  spi_send8(SPI1, 0);
-	  temp=spi_read8(SPI1);
-	  my_usart_print_int(USART2, (temp));
-	  gpio_set(GPIOE, GPIO3);
+		gpio_clear(GPIOE, GPIO3);
+		spi_send8(SPI1, GYR_STATUS_REG | GYR_RNW);
+		spi_read8(SPI1);
+		spi_send8(SPI1, 0);
+		temp=spi_read8(SPI1);
+		my_usart_print_int(USART2, (temp));
+		gpio_set(GPIOE, GPIO3);
 
-	  gpio_clear(GPIOE, GPIO3);
-	  spi_send8(SPI1, GYR_OUT_TEMP | GYR_RNW);
-	  spi_read8(SPI1);
-	  spi_send8(SPI1, 0);
-	  temp=spi_read8(SPI1);
-	  my_usart_print_int(USART2, (temp));
-	  gpio_set(GPIOE, GPIO3);
+		gpio_clear(GPIOE, GPIO3);
+		spi_send8(SPI1, GYR_OUT_TEMP | GYR_RNW);
+		spi_read8(SPI1);
+		spi_send8(SPI1, 0);
+		temp=spi_read8(SPI1);
+		my_usart_print_int(USART2, (temp));
+		gpio_set(GPIOE, GPIO3);
 
-	  gpio_clear(GPIOE, GPIO3);
-	  spi_send8(SPI1, GYR_OUT_X_L | GYR_RNW);
-	  spi_read8(SPI1);
-	  spi_send8(SPI1, 0);
-	  gyr_x=spi_read8(SPI1);
-	  gpio_set(GPIOE, GPIO3);
+		gpio_clear(GPIOE, GPIO3);
+		spi_send8(SPI1, GYR_OUT_X_L | GYR_RNW);
+		spi_read8(SPI1);
+		spi_send8(SPI1, 0);
+		gyr_x=spi_read8(SPI1);
+		gpio_set(GPIOE, GPIO3);
 
-	  gpio_clear(GPIOE, GPIO3);
-	  spi_send8(SPI1, GYR_OUT_X_H | GYR_RNW);
-	  spi_read8(SPI1);
-	  spi_send8(SPI1, 0);
-	  gyr_x|=spi_read8(SPI1) << 8;
-	  my_usart_print_int(USART2, (gyr_x));
-	  gpio_set(GPIOE, GPIO3);
+		gpio_clear(GPIOE, GPIO3);
+		spi_send8(SPI1, GYR_OUT_X_H | GYR_RNW);
+		spi_read8(SPI1);
+		spi_send8(SPI1, 0);
+		gyr_x|=spi_read8(SPI1) << 8;
+		my_usart_print_int(USART2, (gyr_x));
+		gpio_set(GPIOE, GPIO3);
 
-	  int i;
-	  for (i = 0; i < 80000; i++)    /* Wait a bit. */
-	    __asm__("nop");
+		int i;
+		for (i = 0; i < 80000; i++)    /* Wait a bit. */
+			__asm__("nop");
 	}
 
 	return 0;

--- a/examples/stm32/f3/stm32f3-discovery/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f3/stm32f3-discovery/usb_cdcacm/cdcacm.c
@@ -233,16 +233,16 @@ static void cdcacm_set_config(usbd_device *usbd_dev, uint16_t wValue)
 }
 
 
-void usb_setup(void) {
-  /* Enable clocks for GPIO port A (for GPIO_USART2_TX) and USART2. */
-  rcc_usb_prescale_1();
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USBEN);
-  rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
+static void usb_setup(void)
+{
+	/* Enable clocks for GPIO port A (for GPIO_USART2_TX) and USART2. */
+	rcc_usb_prescale_1();
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USBEN);
+	rcc_peripheral_enable_clock(&RCC_AHBENR, RCC_AHBENR_IOPAEN);
 
-  /* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
-  gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
-  gpio_set_af(GPIOA, GPIO_AF14, GPIO11| GPIO12);
-
+	/* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
+	gpio_set_af(GPIOA, GPIO_AF14, GPIO11| GPIO12);
 }
 
 int main(void)
@@ -254,7 +254,8 @@ int main(void)
 	rcc_clock_setup_hsi(&hsi_8mhz[CLOCK_48MHZ]);
 	usb_setup();
 
-	usbd_dev = usbd_init(&stm32f103_usb_driver, &dev, &config, usb_strings, 3, usbd_control_buffer, sizeof(usbd_control_buffer));
+	usbd_dev = usbd_init(&stm32f103_usb_driver, &dev, &config, usb_strings,
+			3, usbd_control_buffer, sizeof(usbd_control_buffer));
 	usbd_register_set_config_callback(usbd_dev, cdcacm_set_config);
 
 	for (i = 0; i < 0x800000; i++)


### PR DESCRIPTION
kuldeepdhaka adressed an issue when F3 examples sometimes crashes to hard fault. -Wstrict-prototypes reveals that there are some undeclared prototypes, so the linker may select other variant with single int parameter instead of void functions.

My solution is to declare these functions as static.

There was a plenty style bugs, so I was corrected it too.
