### PR TITLE
linker script paths: don't hardcode the path

### DIFF
--- a/examples/stm32/f1/stm32vl-discovery/adc-dac-printf/Makefile
+++ b/examples/stm32/f1/stm32vl-discovery/adc-dac-printf/Makefile
@@ -18,7 +18,7 @@
 ##
 
 BINARY = adc-dac-printf
-LDSCRIPT = ../../../../../libopencm3/lib/stm32/f1/stm32f100xb.ld
+LDSCRIPT = $(TOOLCHAIN_DIR)/lib/stm32/f1/stm32f100xb.ld
 
 include ../../Makefile.include
 

--- a/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/Makefile
+++ b/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/Makefile
@@ -18,7 +18,7 @@
 ##
 
 BINARY = main
-LDSCRIPT = ../../../../../libopencm3/lib/stm32/l1/stm32l15xxb.ld
+LDSCRIPT = $(TOOLCHAIN_DIR)/lib/stm32/l1/stm32l15xxb.ld
 
 include ../../Makefile.include
 

--- a/examples/stm32/l1/stm32l-discovery/button-irq-printf/Makefile
+++ b/examples/stm32/l1/stm32l-discovery/button-irq-printf/Makefile
@@ -18,7 +18,7 @@
 ##
 
 BINARY = main
-LDSCRIPT = ../../../../../libopencm3/lib/stm32/l1/stm32l15xxb.ld
+LDSCRIPT = $(TOOLCHAIN_DIR)/lib/stm32/l1/stm32l15xxb.ld
 
 include ../../Makefile.include
 

--- a/examples/stm32/l1/stm32l-discovery/miniblink/Makefile
+++ b/examples/stm32/l1/stm32l-discovery/miniblink/Makefile
@@ -19,7 +19,7 @@
 
 BINARY = miniblink
 
-LDSCRIPT = ../../../../../libopencm3/lib/stm32/l1/stm32l15xxb.ld
+LDSCRIPT = $(TOOLCHAIN_DIR)/lib/stm32/l1/stm32l15xxb.ld
 
 include ../../Makefile.include
 

--- a/examples/stm32/l1/stm32l-discovery/usart-semihosting/Makefile
+++ b/examples/stm32/l1/stm32l-discovery/usart-semihosting/Makefile
@@ -19,7 +19,7 @@
 
 BINARY = usart-semihosting
 
-LDSCRIPT = ../../../../../libopencm3/lib/stm32/l1/stm32l15xxb.ld
+LDSCRIPT = $(TOOLCHAIN_DIR)/lib/stm32/l1/stm32l15xxb.ld
 
 # To disable, run "make ENABLE_SEMIHOSTING=0" or comment next line out
 ENABLE_SEMIHOSTING ?= 1

--- a/examples/stm32/l1/stm32l-discovery/usart/Makefile
+++ b/examples/stm32/l1/stm32l-discovery/usart/Makefile
@@ -19,7 +19,7 @@
 
 BINARY = usart
 
-LDSCRIPT = ../../../../../libopencm3/lib/stm32/l1/stm32l15xxb.ld
+LDSCRIPT = $(TOOLCHAIN_DIR)/lib/stm32/l1/stm32l15xxb.ld
 
 include ../../Makefile.include
 


### PR DESCRIPTION
While some of the examples include a "board.ld" style file, some of them were
pointing to the libopencm3 provided chip specific ld scripts.  When
TOOLCHAIN_DIR has been overridden, those paths were no longer valid/correct.
