### PR TITLE
stm32f4: adc-dac-printf example

### DIFF
--- a/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/Makefile
+++ b/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/Makefile
@@ -1,0 +1,24 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = adc-dac-printf
+LDSCRIPT = ../stm32f4-discovery.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/README
+++ b/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/README
@@ -1,0 +1,17 @@
+Console on PA2 (tx only)  115200@8n1
+
+* Prints the ADC value on PA0 (adc channel 0) on the console
+* Echos half that ADC value out to DAC channel 2 on PA5
+* Prints the ADC value of PA1 (adc channel 1) to the console.
+
+Recommended wiring:
+* pot or any resistor ladder to PA0
+* jumper from PA5 to PA1
+
+example output:
+...
+tick: 228: adc0= 3950, target adc1=1975, adc1=1979
+tick: 229: adc0= 3949, target adc1=1974, adc1=1978
+tick: 230: adc0= 3950, target adc1=1975, adc1=1979
+tick: 231: adc0= 3949, target adc1=1974, adc1=1978
+...

--- a/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/adc-dac-printf.c
+++ b/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/adc-dac-printf.c
@@ -1,0 +1,157 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2014 Karl Palsson <karlp@tweak.net.au>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/stm32/adc.h>
+#include <libopencm3/stm32/dac.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/usart.h>
+
+#define LED_DISCO_GREEN_PORT GPIOD
+#define LED_DISCO_GREEN_PIN GPIO12
+
+#define USART_CONSOLE USART2
+
+int _write(int file, char *ptr, int len);
+
+static void clock_setup(void)
+{
+	rcc_clock_setup_hse_3v3(&hse_8mhz_3v3[CLOCK_3V3_168MHZ]);
+	/* Enable GPIOD clock for LED & USARTs. */
+	rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPDEN);
+	rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPAEN);
+
+	/* Enable clocks for USART2 and dac */
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USART2EN);
+	rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_DACEN);
+
+	/* And ADC*/
+	rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_ADC1EN);
+}
+
+static void usart_setup(void)
+{
+	/* Setup GPIO pins for USART2 transmit. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2);
+
+	/* Setup USART2 TX pin as alternate function. */
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2);
+
+	usart_set_baudrate(USART_CONSOLE, 115200);
+	usart_set_databits(USART_CONSOLE, 8);
+	usart_set_stopbits(USART_CONSOLE, USART_STOPBITS_1);
+	usart_set_mode(USART_CONSOLE, USART_MODE_TX);
+	usart_set_parity(USART_CONSOLE, USART_PARITY_NONE);
+	usart_set_flow_control(USART_CONSOLE, USART_FLOWCONTROL_NONE);
+
+	/* Finally enable the USART. */
+	usart_enable(USART_CONSOLE);
+}
+
+/**
+ * Use USART_CONSOLE as a console.
+ * This is a syscall for newlib
+ * @param file
+ * @param ptr
+ * @param len
+ * @return
+ */
+int _write(int file, char *ptr, int len)
+{
+	int i;
+
+	if (file == STDOUT_FILENO || file == STDERR_FILENO) {
+		for (i = 0; i < len; i++) {
+			if (ptr[i] == '\n') {
+				usart_send_blocking(USART_CONSOLE, '\r');
+			}
+			usart_send_blocking(USART_CONSOLE, ptr[i]);
+		}
+		return i;
+	}
+	errno = EIO;
+	return -1;
+}
+
+static void adc_setup(void)
+{
+	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO0);
+	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO1);
+
+	adc_off(ADC1);
+	adc_disable_scan_mode(ADC1);
+	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR_SMP_3CYC);
+
+	adc_power_on(ADC1);
+
+}
+
+static void dac_setup(void)
+{
+	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO5);
+	dac_disable(CHANNEL_2);
+	dac_disable_waveform_generation(CHANNEL_2);
+	dac_enable(CHANNEL_2);
+	dac_set_trigger_source(DAC_CR_TSEL2_SW);
+}
+
+static uint16_t read_adc_naiive(uint8_t channel)
+{
+	uint8_t channel_array[16];
+	channel_array[0] = channel;
+	adc_set_regular_sequence(ADC1, 1, channel_array);
+	adc_start_conversion_regular(ADC1);
+	while (!adc_eoc(ADC1));
+	uint16_t reg16 = adc_read_regular(ADC1);
+	return reg16;
+}
+
+int main(void)
+{
+	int i;
+	int j = 0;
+	clock_setup();
+	usart_setup();
+	printf("hi guys!\n");
+	adc_setup();
+	dac_setup();
+
+	/* green led for ticking */
+	gpio_mode_setup(LED_DISCO_GREEN_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_DISCO_GREEN_PIN);
+
+
+	while (1) {
+		uint16_t input_adc0 = read_adc_naiive(0);
+		uint16_t target = input_adc0 / 2;
+		dac_load_data_buffer_single(target, RIGHT12, CHANNEL_2);
+		dac_software_trigger(CHANNEL_2);
+		uint16_t input_adc1 = read_adc_naiive(1);
+		printf("tick: %d: adc0= %u, target adc1=%d, adc1=%d\n",
+			j++, input_adc0, target, input_adc1);
+		gpio_toggle(LED_DISCO_GREEN_PORT, LED_DISCO_GREEN_PIN); /* LED on/off */
+		for (i = 0; i < 1000000; i++) /* Wait a bit. */
+			__asm__("NOP");
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This is the same behaviour as the f1 and l1 examples of this code, making it
easier to test changes to unification of the adc code.
