### PR TITLE
[BUILD] Correct inplace build for examples

### DIFF
--- a/examples/Makefile.rules
+++ b/examples/Makefile.rules
@@ -56,10 +56,10 @@ ifeq ($(strip $(OPENCM3_DIR)),)
 # user has not specified the library path, so we try to detect it
 
 # where we search for the library
-LIBPATHS := ./libopencm3 ../../../../../libopencm3
+LIBPATHS := ./libopencm3 ../../../../libopencm3 ../../../../../libopencm3
 
 OPENCM3_DIR := $(wildcard $(LIBPATHS:=/locm3.sublime-project))
-OPENCM3_DIR := $(firstword $(shell dirname $(OPENCM3_DIR)))
+OPENCM3_DIR := $(firstword $(dir $(OPENCM3_DIR)))
 
 ifeq ($(strip $(OPENCM3_DIR)),)
 $(warning Cannot find libopencm3 library in the standard search paths.)


### PR DESCRIPTION
Correct build of only one example of lpc and tiva.

The LM3S/LM4F/lpcxx examples is in another directory depth, therefore they see the library in another placement.

Fix adds this less-deep directory to the search paths
