### PR TITLE
stm32l: Correct openocd flash target name

### DIFF
--- a/examples/stm32/l1/Makefile.include
+++ b/examples/stm32/l1/Makefile.include
@@ -29,7 +29,7 @@ ARCH_FLAGS	= -mthumb -mcpu=cortex-m3 $(FP_FLAGS) -mfix-cortex-m3-ldrd
 
 OOCD		?= openocd
 OOCD_INTERFACE	?= stlink-v2
-OOCD_BOARD	?= stm32l1discovery
+OOCD_BOARD	?= stm32ldiscovery
 
 ################################################################################
 # Black Magic Probe specific variables


### PR DESCRIPTION
Just a simple fix for the examples, this was always expected to possible have some minor niggles
