### PR TITLE
[BUILD] Make the binaries only needed for the user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,21 @@ MAKEFLAGS += --no-print-directory
 endif
 
 OPENCM3_DIR := $(realpath libopencm3)
+EXAMPLE_RULES = elf
 
 all: build
+
+bin: EXAMPLE_RULES += bin
+hex: EXAMPLE_RULES += hex
+srec: EXAMPLE_RULES += srec
+list: EXAMPLE_RULES += list
+images: EXAMPLE_RULES += images
+
+bin: build
+hex: build
+srec: build
+list: build
+images: build
 
 build: lib examples
 
@@ -54,7 +67,7 @@ lib:
 EXAMPLE_DIRS:=$(sort $(dir $(wildcard $(addsuffix /*/*/Makefile,$(addprefix examples/,$(TARGETS))))))
 $(EXAMPLE_DIRS): lib
 	@printf "  BUILD   $@\n";
-	$(Q)$(MAKE) --directory=$@ OPENCM3_DIR=$(OPENCM3_DIR)
+	$(Q)$(MAKE) --directory=$@ OPENCM3_DIR=$(OPENCM3_DIR) $(EXAMPLE_RULES)
 
 examples: $(EXAMPLE_DIRS)
 	$(Q)true
@@ -79,5 +92,6 @@ styleclean: $(EXAMPLE_DIRS:=.styleclean)
 	$(Q)$(MAKE) -C $* stylecheck OPENCM3_DIR=$(OPENCM3_DIR)
 
 
-.PHONY: build lib examples $(EXAMPLE_DIRS) install clean stylecheck styleclean
+.PHONY: build lib examples $(EXAMPLE_DIRS) install clean stylecheck styleclean \
+        bin hex srec list images
 

--- a/examples/Makefile.rules
+++ b/examples/Makefile.rules
@@ -123,7 +123,13 @@ LDLIBS		+= -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group
 .SECONDEXPANSION:
 .SECONDARY:
 
-all: images
+all: elf
+
+elf: $(BINARY).elf
+bin: $(BINARY).bin
+hex: $(BINARY).hex
+srec: $(BINARY).srec
+list: $(BINARY).list
 
 images: $(BINARY).images
 flash: $(BINARY).flash
@@ -228,6 +234,6 @@ else
 		   $(*).elf
 endif
 
-.PHONY: images clean stylecheck styleclean
+.PHONY: images clean stylecheck styleclean elf bin hex srec list
 
 -include $(OBJS:.o=.d)


### PR DESCRIPTION
User can specify which binaries he needs on the commandline.

'make hex' will build examples with generating hex file
'make hex bin' will build hex and bin output
'make images' will build all images as in previous versions of buildsystem
'make all' or 'make' will build only elf files

This will have huge impact on build speed.
For the 'map' target to work correctly, this commit depends on libopencm3/libopencm3#262 of the library and #50 of the examples

This solves issue #48
