### PR TITLE
STM32F1xx RTC example: Change usart_send to blocking form to allow time ...

### DIFF
--- a/examples/stm32/f1/other/rtc/rtc.c
+++ b/examples/stm32/f1/other/rtc/rtc.c
@@ -83,12 +83,13 @@ void rtc_isr(void)
 	/* Display the current counter value in binary via USART1. */
 	for (j = 0; j < 32; j++) {
 		if ((c & (0x80000000 >> j)) != 0) {
-			usart_send(USART1, '1');
+			usart_send_blocking(USART1, '1');
 		} else {
-			usart_send(USART1, '0');
+			usart_send_blocking(USART1, '0');
 		}
 	}
-	usart_send(USART1, '\n');
+	usart_send_blocking(USART1, '\n');
+	usart_send_blocking(USART1, '\r');
 }
 
 int main(void)


### PR DESCRIPTION
...to send characters

Tested with ET-STAMP-STM32