### PR TITLE
Examples for the vf6xx Cortex-M4 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ TARGETS		:= stm32/f0 stm32/f1 stm32/f2 stm32/f3 stm32/f4 stm32/l1
 TARGETS		+= lpc13xx lpc17xx #lpc43xx
 TARGETS		+= lm3s lm4f
 TARGETS		+= efm32/efm32tg efm32/efm32g efm32/efm32lg efm32/efm32gg
+TARGETS		+= vf6xx
 
 # Be silent per default, but 'make V=1' will show all compiler calls.
 ifneq ($(V),1)

--- a/examples/vf6xx/colibri-vf61/Makefile.include
+++ b/examples/vf6xx/colibri-vf61/Makefile.include
@@ -1,0 +1,32 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2010 Piotr Esden-Tempski <piotr@esden.net>
+## Copyright (C) 2011 Fergus Noble <fergusnoble@gmail.com>
+## Copyright (C) 2014 Stefan Agner <stefan@agner.ch>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+LIBNAME		= opencm3_vf6xx
+DEFS		= -DVF6XX
+
+FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
+ARCH_FLAGS	= -mthumb -mcpu=cortex-m4 $(FP_FLAGS)
+
+include ../../../Makefile.rules
+
+
+

--- a/examples/vf6xx/colibri-vf61/colibri-vf61.ld
+++ b/examples/vf6xx/colibri-vf61/colibri-vf61.ld
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2014 Stefan Agner <stefan@agner.ch>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for Colibri VF61 (Vybrid VF610, use sysRAM0, 512KiB). */
+
+/* Define memory regions. */
+MEMORY
+{
+	/*
+	 * Note: 0x1f000000 is an alias for code bus to the same memory
+	 * located at 0x3f000000, hence start with the data section
+	 * at an offset of 256KiB. One can define this section lenghts
+	 * freely
+	 */
+	pc_ram (rwx) : ORIGIN = 0x1f000000, LENGTH = 256K
+	ps_ram (rwx) : ORIGIN = 0x3f040000, LENGTH = 256K
+}
+
+/* Include the common ld script. */
+INCLUDE libopencm3_vf6xx.ld
+

--- a/examples/vf6xx/colibri-vf61/gpio/Makefile
+++ b/examples/vf6xx/colibri-vf61/gpio/Makefile
@@ -1,0 +1,26 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2014 Stefan Agner <stefan@agner.ch>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = gpio
+
+LDSCRIPT = ../colibri-vf61.ld
+
+include ../Makefile.include
+

--- a/examples/vf6xx/colibri-vf61/gpio/gpio.c
+++ b/examples/vf6xx/colibri-vf61/gpio/gpio.c
@@ -1,0 +1,95 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2014 Stefan Agner <stefan@agner.ch>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/vf6xx/ccm.h>
+#include <libopencm3/vf6xx/uart.h>
+#include <libopencm3/vf6xx/gpio.h>
+#include <libopencm3/vf6xx/iomuxc.h>
+
+
+static const uint32_t gpio_out = IOMUXC_PAD(MUX_MODE_ALT0, SPEED_LOW, \
+			DSE_150OHM, PUS_PU_100KOHM, IOMUXC_OBE | IOMUXC_IBE);
+
+static const uint32_t gpio_in = IOMUXC_PAD(MUX_MODE_ALT0, SPEED_LOW, \
+			DSE_150OHM, PUS_PU_100KOHM, IOMUXC_IBE);
+
+int _write(int file, char *ptr, int len);
+void sys_tick_handler(void);
+
+int _write(int file, char *ptr, int len)
+{
+	int i;
+
+	if (file == 1) {
+		for (i = 0; i < len; i++)
+			uart_send_blocking(UART2, ptr[i]);
+		return i;
+	}
+
+	errno = EIO;
+	return -1;
+}
+
+static void uart_init()
+{
+	ccm_clock_gate_enable(CG9_UART2);
+	uart_enable(UART2);
+	uart_set_baudrate(UART2, 115200);
+}
+
+int main(void)
+{
+	int old_state = -1;
+	int new_state = 0;
+
+
+	/* Init Clock Control and UART */
+	ccm_calculate_clocks();
+	uart_init();
+
+	/* Iris Carrier Board, X16, Pin 15 */
+	iomuxc_mux(PTC3, gpio_out);
+
+	/* Iris Carrier Board, X16, Pin 16 */
+	iomuxc_mux(PTC2, gpio_in);
+
+	gpio_set(PTC3);
+	printf("GPIO %d is %s\r\n", PTC3, gpio_get(PTC3) ? "high" : "low");
+
+	/*
+	 * Read input GPIO in a loop and print changes
+	 * A jumper between PTC3<=> PTC2 can be used to set PTC2 to high
+	 */
+	while (1) {
+		new_state = gpio_get(PTC2);
+		if (old_state != new_state) {
+			printf("GPIO %d is %s\r\n", PTC2,
+				new_state ? "high" : "low");
+			old_state = new_state;
+		}
+	}
+
+
+	return 0;
+}
+

--- a/examples/vf6xx/colibri-vf61/uart/Makefile
+++ b/examples/vf6xx/colibri-vf61/uart/Makefile
@@ -1,0 +1,26 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2014 Stefan Agner <stefan@agner.ch>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = uart
+
+LDSCRIPT = ../colibri-vf61.ld
+
+include ../Makefile.include
+

--- a/examples/vf6xx/colibri-vf61/uart/uart.c
+++ b/examples/vf6xx/colibri-vf61/uart/uart.c
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2014 Stefan Agner <stefan@agner.ch>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <libopencm3/cm3/common.h>
+#include <libopencm3/vf6xx/ccm.h>
+#include <libopencm3/vf6xx/uart.h>
+
+int _write(int file, char *ptr, int len);
+
+int _write(int file, char *ptr, int len)
+{
+	int i;
+
+	if (file == 1) {
+		for (i = 0; i < len; i++)
+			uart_send_blocking(UART2, ptr[i]);
+		return i;
+	}
+
+	errno = EIO;
+	return -1;
+}
+
+static void uart_init(void)
+{
+	ccm_clock_gate_enable(CG9_UART2);
+	uart_enable(UART2);
+	uart_set_baudrate(UART2, 115200);
+}
+
+int main(void)
+{
+	int counter = 0; 
+	float fcounter = 0.0;
+	double dcounter = 0.0;
+
+	ccm_calculate_clocks();
+	uart_init();
+
+	/*
+	 * Write Hello World an integer, float and double all over
+	 * again while incrementing the numbers.
+	 */
+	while (1) {
+		printf("Hello World! %i %f %f\r\n", counter, fcounter,
+		       dcounter);
+		counter++;
+		fcounter += 0.01;
+		dcounter += 0.01;
+	}
+
+	return 0;
+}
+


### PR DESCRIPTION
Two working examples for the Cortex-M4 core of Freescale Vybrid vf6xx.