### PR TITLE
Fixes STM32 examples to compile with link-time optimizations.

### DIFF
--- a/examples/stm32/f1/lisa-m-2/spi/spi.c
+++ b/examples/stm32/f1/lisa-m-2/spi/spi.c
@@ -27,7 +27,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/f1/lisa-m-2/spi_dma/spi_dma.c
+++ b/examples/stm32/f1/lisa-m-2/spi_dma/spi_dma.c
@@ -47,7 +47,7 @@ typedef enum {
 
 volatile trans_status transceive_status;
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/f1/lisa-m-2/spi_dma_adv/spi_dma_adv.c
+++ b/examples/stm32/f1/lisa-m-2/spi_dma_adv/spi_dma_adv.c
@@ -57,7 +57,7 @@ uint16_t dummy_tx_buf = 0xdd;
 uint8_t dummy_tx_buf = 0xdd;
 #endif
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/f1/lisa-m-2/usart_irq_printf/usart_irq_printf.c
+++ b/examples/stm32/f1/lisa-m-2/usart_irq_printf/usart_irq_printf.c
@@ -45,7 +45,7 @@ struct ring {
 #define RING_DATA(RING)  (RING)->data
 #define RING_EMPTY(RING) ((RING)->begin == (RING)->end)
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void ring_init(struct ring *ring, uint8_t *buf, ring_size_t size)
 {

--- a/examples/stm32/f1/lisa-m-2/usart_printf/usart_printf.c
+++ b/examples/stm32/f1/lisa-m-2/usart_printf/usart_printf.c
@@ -25,7 +25,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/f1/stm32-h103/usart_irq_printf/usart_irq_printf.c
+++ b/examples/stm32/f1/stm32-h103/usart_irq_printf/usart_irq_printf.c
@@ -113,7 +113,7 @@ static int32_t ring_read(struct ring *ring, uint8_t *data, ring_size_t size)
 struct ring output_ring;
 uint8_t output_ring_buffer[BUFFER_SIZE];
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/f1/stm32-h103/usart_printf/usart_printf.c
+++ b/examples/stm32/f1/stm32-h103/usart_printf/usart_printf.c
@@ -25,7 +25,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/f1/stm32vl-discovery/adc-dac-printf/adc-dac-printf.c
+++ b/examples/stm32/f1/stm32vl-discovery/adc-dac-printf/adc-dac-printf.c
@@ -33,7 +33,7 @@
 
 #define USART_CONSOLE USART2
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/f2/jobygps/spi_test/spi_test.c
+++ b/examples/stm32/f2/jobygps/spi_test/spi_test.c
@@ -26,7 +26,7 @@
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/rcc.h>
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/f2/jobygps/usart_printf/usart_printf.c
+++ b/examples/stm32/f2/jobygps/usart_printf/usart_printf.c
@@ -25,7 +25,7 @@
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/rcc.h>
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/adc-dac-printf.c
+++ b/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/adc-dac-printf.c
@@ -32,7 +32,7 @@
 
 #define USART_CONSOLE USART2
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {

--- a/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/main.c
+++ b/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/main.c
@@ -36,7 +36,7 @@
 
 static volatile struct state_t state;
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static inline __attribute__((always_inline)) void __WFI(void)
 {

--- a/examples/stm32/l1/stm32l-discovery/button-irq-printf/main.c
+++ b/examples/stm32/l1/stm32l-discovery/button-irq-printf/main.c
@@ -31,7 +31,7 @@
 
 static struct state_t state;
 
-int _write(int file, char *ptr, int len);
+int __attribute__((used)) _write(int file, char *ptr, int len);
 
 static void clock_setup(void)
 {


### PR DESCRIPTION
When newlib is compiled without LTO, the linker wrongly discards
functions provided by user code but unreferenced from LTO compiled
code.

Thus, we need to mark with attribute((used)) functions that should be
called from the library.
