### PR TITLE
Modified the usbdfu example for stm32-h103. Previously the control callb...

### DIFF
--- a/examples/stm32/f1/stm32-h103/usb_dfu/usbdfu.c
+++ b/examples/stm32/f1/stm32-h103/usb_dfu/usbdfu.c
@@ -229,6 +229,18 @@ static int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 	return 0;
 }
 
+static void usbdfu_set_config(usbd_device *usbd_dev, uint16_t wValue)
+{
+	(void)wValue;
+	(void)usbd_dev;
+
+	usbd_register_control_callback(
+				usbd_dev,
+				USB_REQ_TYPE_CLASS | USB_REQ_TYPE_INTERFACE,
+				USB_REQ_TYPE_TYPE | USB_REQ_TYPE_RECIPIENT,
+				usbdfu_control_request);
+}
+
 int main(void)
 {
 	usbd_device *usbd_dev;
@@ -257,11 +269,7 @@ int main(void)
 	gpio_set(GPIOC, GPIO11);
 
 	usbd_dev = usbd_init(&stm32f103_usb_driver, &dev, &config, usb_strings, 4, usbd_control_buffer, sizeof(usbd_control_buffer));
-	usbd_register_control_callback(
-				usbd_dev,
-				USB_REQ_TYPE_CLASS | USB_REQ_TYPE_INTERFACE,
-				USB_REQ_TYPE_TYPE | USB_REQ_TYPE_RECIPIENT,
-				usbdfu_control_request);
+	usbd_register_set_config_callback(usbd_dev, usbdfu_set_config);
 
 	gpio_clear(GPIOC, GPIO11);
 


### PR DESCRIPTION
...ack function wasnt called, since it was cleared in the handler for the SET_CONFIG std. request. Registering a callback for the "set configuration" request and setting the control callback from this resolves the issue. Tested with dfu-tool 0.8. Works.