### PR TITLE
Fix usage of USB_VBUS

### DIFF
--- a/examples/stm32/f4/stm32f4-discovery/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f4/stm32f4-discovery/usb_cdcacm/cdcacm.c
@@ -231,9 +231,8 @@ int main(void)
 	rcc_periph_clock_enable(RCC_GPIOA);
 	rcc_periph_clock_enable(RCC_OTGFS);
 
-	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE,
-			GPIO9 | GPIO11 | GPIO12);
-	gpio_set_af(GPIOA, GPIO_AF10, GPIO9 | GPIO11 | GPIO12);
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
+	gpio_set_af(GPIOA, GPIO_AF10, GPIO11 | GPIO12);
 
 	usbd_dev = usbd_init(&otgfs_usb_driver, &dev, &config,
 			usb_strings, 3,

--- a/examples/stm32/f4/stm32f4-discovery/usb_midi/usbmidi.c
+++ b/examples/stm32/f4/stm32f4-discovery/usb_midi/usbmidi.c
@@ -367,9 +367,8 @@ int main(void)
 	rcc_periph_clock_enable(RCC_OTGFS);
 
 	/* USB pins */
-	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE,
-			GPIO9 | GPIO11 | GPIO12);
-	gpio_set_af(GPIOA, GPIO_AF10, GPIO9 | GPIO11 | GPIO12);
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
+	gpio_set_af(GPIOA, GPIO_AF10, GPIO11 | GPIO12);
 
 	/* Button pin */
 	gpio_mode_setup(GPIOA, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO0);

--- a/examples/stm32/f4/stm32f4-discovery/usb_msc/msc.c
+++ b/examples/stm32/f4/stm32f4-discovery/usb_msc/msc.c
@@ -109,9 +109,8 @@ int main(void)
 	rcc_periph_clock_enable(RCC_GPIOA);
 	rcc_periph_clock_enable(RCC_OTGFS);
 
-	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE,
-			GPIO9 | GPIO11 | GPIO12);
-	gpio_set_af(GPIOA, GPIO_AF10, GPIO9 | GPIO11 | GPIO12);
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
+	gpio_set_af(GPIOA, GPIO_AF10, GPIO11 | GPIO12);
 
 	msc_dev = usbd_init(&otgfs_usb_driver, &dev_descr, &config_descr,
 			    usb_strings, 3,

--- a/examples/stm32/f4/stm32f429i-discovery/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f4/stm32f429i-discovery/usb_cdcacm/cdcacm.c
@@ -232,9 +232,8 @@ int main(void)
 	rcc_periph_clock_enable(RCC_GPIOB);
 	rcc_periph_clock_enable(RCC_OTGHS);
 
-	gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE,
-			GPIO13 | GPIO14 | GPIO15);
-	gpio_set_af(GPIOB, GPIO_AF12, GPIO13 | GPIO14 | GPIO15);
+	gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO14 | GPIO15);
+	gpio_set_af(GPIOB, GPIO_AF12, GPIO14 | GPIO15);
 
 	usbd_dev = usbd_init(&otghs_usb_driver, &dev, &config,
 			usb_strings, 3,

--- a/examples/stm32/f4/stm32f429i-discovery/usb_midi/usbmidi.c
+++ b/examples/stm32/f4/stm32f429i-discovery/usb_midi/usbmidi.c
@@ -369,9 +369,8 @@ int main(void)
 	rcc_periph_clock_enable(RCC_OTGHS);
 
 	/* USB pins */
-	gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE,
-			GPIO13 | GPIO14 | GPIO15);
-	gpio_set_af(GPIOB, GPIO_AF12, GPIO13 | GPIO14 | GPIO15);
+	gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO14 | GPIO15);
+	gpio_set_af(GPIOB, GPIO_AF12, GPIO14 | GPIO15);
 
 	/* Button pin */
 	gpio_mode_setup(GPIOA, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO0);

--- a/examples/stm32/f4/stm32f429i-discovery/usb_msc/msc.c
+++ b/examples/stm32/f4/stm32f429i-discovery/usb_msc/msc.c
@@ -110,9 +110,8 @@ int main(void)
 	rcc_periph_clock_enable(RCC_GPIOB);
 	rcc_periph_clock_enable(RCC_OTGHS);
 
-	gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE,
-			GPIO13 | GPIO14 | GPIO15);
-	gpio_set_af(GPIOB, GPIO_AF12, GPIO13 | GPIO14 | GPIO15);
+	gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO14 | GPIO15);
+	gpio_set_af(GPIOB, GPIO_AF12, GPIO14 | GPIO15);
 
 	msc_dev = usbd_init(&otghs_usb_driver, &dev_descr, &config_descr,
 			    usb_strings, 3,


### PR DESCRIPTION
USB_VBUS is not an alternate function, it is an additionnal function which is
always enabled.

If configured as an alternate function, it will draw current from VBUS.

I grepped for AF10 & AF12 in examples.
