### PR TITLE
[BUILD] Report proper error when linker script cannot be found.

### DIFF
--- a/examples/Makefile.rules
+++ b/examples/Makefile.rules
@@ -134,6 +134,11 @@ list: $(BINARY).list
 images: $(BINARY).images
 flash: $(BINARY).flash
 
+$(LDSCRIPT):
+    ifeq (,$(wildcard $(LDSCRIPT)))
+        $(error Unable to find specified linker script: $(LDSCRIPT))
+    endif
+
 %.images: %.bin %.hex %.srec %.list %.map
 	@#printf "*** $* images generated ***\n"
 


### PR DESCRIPTION
By default, the error message when linker script cannot be found is not that nice:
```
make: *** No rule to make target 'miniblink.elf', needed by 'elf'.  Stop.
```