### PR TITLE
usb: Use enumerated return codes and usbd_control_complete_callback type

### DIFF
--- a/examples/stm32/f1/lisa-m-1/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/lisa-m-1/usb_cdcacm/cdcacm.c
@@ -166,8 +166,10 @@ static const char *usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+cdcacm_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)buf;
@@ -192,15 +194,15 @@ static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		local_buf[8] = req->wValue & 3;
 		local_buf[9] = 0;
 		// usbd_ep_write_packet(0x83, buf, 10);
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case USB_CDC_REQ_SET_LINE_CODING:
 		if (*len < sizeof(struct usb_cdc_line_coding))
-			return 0;
+			return USBD_REQ_NOTSUPP;
 
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)

--- a/examples/stm32/f1/lisa-m-1/usb_dfu/usbdfu.c
+++ b/examples/stm32/f1/lisa-m-1/usb_dfu/usbdfu.c
@@ -174,39 +174,41 @@ static void usbdfu_getstatus_complete(usbd_device *usbd_dev, struct usb_setup_da
 	}
 }
 
-static int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+usbdfu_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)usbd_dev;
 
 	if ((req->bmRequestType & 0x7F) != 0x21)
-		return 0; /* Only accept class request. */
+		return USBD_REQ_NOTSUPP; /* Only accept class request. */
 
 	switch (req->bRequest) {
 	case DFU_DNLOAD:
 		if ((len == NULL) || (*len == 0)) {
 			usbdfu_state = STATE_DFU_MANIFEST_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		} else {
 			/* Copy download data for use on GET_STATUS. */
 			prog.blocknum = req->wValue;
 			prog.len = *len;
 			memcpy(prog.buf, *buf, *len);
 			usbdfu_state = STATE_DFU_DNLOAD_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		}
 	case DFU_CLRSTATUS:
 		/* Clear error and return to dfuIDLE. */
 		if (usbdfu_state == STATE_DFU_ERROR)
 			usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_ABORT:
 		/* Abort returns to dfuIDLE state. */
 		usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_UPLOAD:
 		/* Upload not supported for now. */
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	case DFU_GETSTATUS: {
 		uint32_t bwPollTimeout = 0; /* 24-bit integer in DFU class spec */
 		(*buf)[0] = usbdfu_getstatus(&bwPollTimeout);
@@ -217,16 +219,16 @@ static int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		(*buf)[5] = 0; /* iString not used here */
 		*len = 6;
 		*complete = usbdfu_getstatus_complete;
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case DFU_GETSTATE:
 		/* Return state with no state transision. */
 		*buf[0] = usbdfu_state;
 		*len = 1;
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
 
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 int main(void)

--- a/examples/stm32/f1/lisa-m-1/usb_hid/usbhid.c
+++ b/examples/stm32/f1/lisa-m-1/usb_hid/usbhid.c
@@ -205,8 +205,10 @@ static const char *usb_strings[] = {
 /* Buffer used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int hid_control_request(usbd_device *dev, struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-			void (**complete)(usbd_device *dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+hid_control_request(usbd_device *dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)dev;
@@ -214,13 +216,13 @@ static int hid_control_request(usbd_device *dev, struct usb_setup_data *req, uin
 	if((req->bmRequestType != 0x81) ||
 	   (req->bRequest != USB_REQ_GET_DESCRIPTOR) ||
 	   (req->wValue != 0x2200))
-		return 0;
+		return USBD_REQ_NOTSUPP;
 
 	/* Handle the HID report descriptor. */
 	*buf = (uint8_t *)hid_report_descriptor;
 	*len = sizeof(hid_report_descriptor);
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
 #ifdef INCLUDE_DFU_INTERFACE
@@ -236,19 +238,22 @@ static void dfu_detach_complete(usbd_device *dev, struct usb_setup_data *req)
 	scb_reset_core();
 }
 
-static int dfu_control_request(usbd_device *dev, struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-			void (**complete)(usbd_device *dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+dfu_control_request(usbd_device *dev,
+			struct usb_setup_data *req,
+			uint8_t **buf, uint16_t *len,
+			usbd_control_complete_callback *complete)
 {
 	(void)buf;
 	(void)len;
 	(void)dev;
 
 	if ((req->bmRequestType != 0x21) || (req->bRequest != DFU_DETACH))
-		return 0; /* Only accept class request. */
+		return USBD_REQ_NOTSUPP; /* Only accept class request. */
 
 	*complete = dfu_detach_complete;
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 #endif
 

--- a/examples/stm32/f1/other/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/other/usb_cdcacm/cdcacm.c
@@ -166,8 +166,10 @@ static const char *usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+cdcacm_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)buf;
@@ -192,15 +194,15 @@ static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		local_buf[8] = req->wValue & 3;
 		local_buf[9] = 0;
 		// usbd_ep_write_packet(0x83, buf, 10);
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
-	case USB_CDC_REQ_SET_LINE_CODING: 
+	case USB_CDC_REQ_SET_LINE_CODING:
 		if(*len < sizeof(struct usb_cdc_line_coding))
-			return 0;
+			return USBD_REQ_NOTSUPP;
 
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)

--- a/examples/stm32/f1/other/usb_dfu/usbdfu.c
+++ b/examples/stm32/f1/other/usb_dfu/usbdfu.c
@@ -174,39 +174,41 @@ static void usbdfu_getstatus_complete(usbd_device *usbd_dev, struct usb_setup_da
 	}
 }
 
-static int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+usbdfu_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)usbd_dev;
 
 	if ((req->bmRequestType & 0x7F) != 0x21)
-		return 0; /* Only accept class request. */
+		return USBD_REQ_NOTSUPP; /* Only accept class request. */
 
 	switch (req->bRequest) {
 	case DFU_DNLOAD:
 		if ((len == NULL) || (*len == 0)) {
 			usbdfu_state = STATE_DFU_MANIFEST_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		} else {
 			/* Copy download data for use on GET_STATUS. */
 			prog.blocknum = req->wValue;
 			prog.len = *len;
 			memcpy(prog.buf, *buf, *len);
 			usbdfu_state = STATE_DFU_DNLOAD_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		}
 	case DFU_CLRSTATUS:
 		/* Clear error and return to dfuIDLE. */
 		if (usbdfu_state == STATE_DFU_ERROR)
 			usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_ABORT:
 		/* Abort returns to dfuIDLE state. */
 		usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_UPLOAD:
 		/* Upload not supported for now. */
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	case DFU_GETSTATUS: {
 		uint32_t bwPollTimeout = 0; /* 24-bit integer in DFU class spec */
 		(*buf)[0] = usbdfu_getstatus(&bwPollTimeout);
@@ -217,16 +219,16 @@ static int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		(*buf)[5] = 0; /* iString not used here */
 		*len = 6;
 		*complete = usbdfu_getstatus_complete;
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case DFU_GETSTATE:
 		/* Return state with no state transision. */
 		*buf[0] = usbdfu_state;
 		*len = 1;
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
 
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 int main(void)

--- a/examples/stm32/f1/other/usb_hid/usbhid.c
+++ b/examples/stm32/f1/other/usb_hid/usbhid.c
@@ -201,8 +201,10 @@ static const char *usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int hid_control_request(usbd_device *dev, struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-			void (**complete)(usbd_device *, struct usb_setup_data *))
+static enum usbd_request_return_codes
+hid_control_request(usbd_device *dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)dev;
@@ -210,13 +212,13 @@ static int hid_control_request(usbd_device *dev, struct usb_setup_data *req, uin
 	if((req->bmRequestType != 0x81) ||
 	   (req->bRequest != USB_REQ_GET_DESCRIPTOR) ||
 	   (req->wValue != 0x2200))
-		return 0;
+		return USBD_REQ_NOTSUPP;
 
 	/* Handle the HID report descriptor. */
 	*buf = (uint8_t *)hid_report_descriptor;
 	*len = sizeof(hid_report_descriptor);
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
 #ifdef INCLUDE_DFU_INTERFACE
@@ -232,19 +234,21 @@ static void dfu_detach_complete(usbd_device *dev, struct usb_setup_data *req)
 	scb_reset_core();
 }
 
-static int dfu_control_request(usbd_device *dev, struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-			void (**complete)(usbd_device *, struct usb_setup_data *))
+static enum usbd_request_return_codes
+dfu_control_request(usbd_device *dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)buf;
 	(void)len;
 	(void)dev;
 
 	if ((req->bmRequestType != 0x21) || (req->bRequest != DFU_DETACH))
-		return 0; /* Only accept class request. */
+		return USBD_REQ_NOTSUPP; /* Only accept class request. */
 
 	*complete = dfu_detach_complete;
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 #endif
 

--- a/examples/stm32/f1/stm32-h103/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/stm32-h103/usb_cdcacm/cdcacm.c
@@ -166,8 +166,10 @@ static const char *usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+cdcacm_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)buf;
@@ -192,14 +194,14 @@ static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		local_buf[8] = req->wValue & 3;
 		local_buf[9] = 0;
 		// usbd_ep_write_packet(0x83, buf, 10);
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case USB_CDC_REQ_SET_LINE_CODING:
 		if (*len < sizeof(struct usb_cdc_line_coding))
-			return 0;
-		return 1;
+			return USBD_REQ_NOTSUPP;
+		return USBD_REQ_HANDLED;
 	}
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)

--- a/examples/stm32/f1/stm32-h103/usb_dfu/usbdfu.c
+++ b/examples/stm32/f1/stm32-h103/usb_dfu/usbdfu.c
@@ -176,37 +176,39 @@ static void usbdfu_getstatus_complete(usbd_device *usbd_dev, struct usb_setup_da
 	}
 }
 
-static int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+usbdfu_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	if ((req->bmRequestType & 0x7F) != 0x21)
-		return 0; /* Only accept class request. */
+		return USBD_REQ_NOTSUPP; /* Only accept class request. */
 
 	switch (req->bRequest) {
 	case DFU_DNLOAD:
 		if ((len == NULL) || (*len == 0)) {
 			usbdfu_state = STATE_DFU_MANIFEST_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		} else {
 			/* Copy download data for use on GET_STATUS. */
 			prog.blocknum = req->wValue;
 			prog.len = *len;
 			memcpy(prog.buf, *buf, *len);
 			usbdfu_state = STATE_DFU_DNLOAD_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		}
 	case DFU_CLRSTATUS:
 		/* Clear error and return to dfuIDLE. */
 		if (usbdfu_state == STATE_DFU_ERROR)
 			usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_ABORT:
 		/* Abort returns to dfuIDLE state. */
 		usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_UPLOAD:
 		/* Upload not supported for now. */
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	case DFU_GETSTATUS: {
 		uint32_t bwPollTimeout = 0; /* 24-bit integer in DFU class spec */
 		(*buf)[0] = usbdfu_getstatus(usbd_dev, &bwPollTimeout);
@@ -217,16 +219,16 @@ static int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		(*buf)[5] = 0; /* iString not used here */
 		*len = 6;
 		*complete = usbdfu_getstatus_complete;
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case DFU_GETSTATE:
 		/* Return state with no state transision. */
 		*buf[0] = usbdfu_state;
 		*len = 1;
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
 
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 int main(void)

--- a/examples/stm32/f1/stm32-h103/usb_hid/usbhid.c
+++ b/examples/stm32/f1/stm32-h103/usb_hid/usbhid.c
@@ -198,8 +198,10 @@ static const char *usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int hid_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-			void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+hid_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)usbd_dev;
@@ -207,13 +209,13 @@ static int hid_control_request(usbd_device *usbd_dev, struct usb_setup_data *req
 	if ((req->bmRequestType != 0x81) ||
 	   (req->bRequest != USB_REQ_GET_DESCRIPTOR) ||
 	   (req->wValue != 0x2200))
-		return 0;
+		return USBD_REQ_NOTSUPP;
 
 	/* Handle the HID report descriptor. */
 	*buf = (uint8_t *)hid_report_descriptor;
 	*len = sizeof(hid_report_descriptor);
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
 #ifdef INCLUDE_DFU_INTERFACE
@@ -229,19 +231,21 @@ static void dfu_detach_complete(usbd_device *usbd_dev, struct usb_setup_data *re
 	scb_reset_core();
 }
 
-static int dfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-			void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+dfu_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)buf;
 	(void)len;
 	(void)usbd_dev;
 
 	if ((req->bmRequestType != 0x21) || (req->bRequest != DFU_DETACH))
-		return 0; /* Only accept class request. */
+		return USBD_REQ_NOTSUPP; /* Only accept class request. */
 
 	*complete = dfu_detach_complete;
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 #endif
 

--- a/examples/stm32/f1/stm32-h103/usb_iap/usbiap.c
+++ b/examples/stm32/f1/stm32-h103/usb_iap/usbiap.c
@@ -176,37 +176,39 @@ static void usbdfu_getstatus_complete(usbd_device *usbd_dev, struct usb_setup_da
 	}
 }
 
-static int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+usbdfu_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	if ((req->bmRequestType & 0x7F) != 0x21)
-		return 0; /* Only accept class request. */
+		return USBD_REQ_NOTSUPP; /* Only accept class request. */
 
 	switch (req->bRequest) {
 	case DFU_DNLOAD:
 		if ((len == NULL) || (*len == 0)) {
 			usbdfu_state = STATE_DFU_MANIFEST_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		} else {
 			/* Copy download data for use on GET_STATUS. */
 			prog.blocknum = req->wValue;
 			prog.len = *len;
 			memcpy(prog.buf, *buf, *len);
 			usbdfu_state = STATE_DFU_DNLOAD_SYNC;
-			return 1;
+			return USBD_REQ_HANDLED;
 		}
 	case DFU_CLRSTATUS:
 		/* Clear error and return to dfuIDLE. */
 		if (usbdfu_state == STATE_DFU_ERROR)
 			usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_ABORT:
 		/* Abort returns to dfuIDLE state. */
 		usbdfu_state = STATE_DFU_IDLE;
-		return 1;
+		return USBD_REQ_HANDLED;
 	case DFU_UPLOAD:
 		/* Upload not supported for now. */
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	case DFU_GETSTATUS: {
 		uint32_t bwPollTimeout = 0; /* 24-bit integer in DFU class spec */
 		(*buf)[0] = usbdfu_getstatus(usbd_dev, &bwPollTimeout);
@@ -217,16 +219,16 @@ static int usbdfu_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		(*buf)[5] = 0; /* iString not used here */
 		*len = 6;
 		*complete = usbdfu_getstatus_complete;
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case DFU_GETSTATE:
 		/* Return state with no state transision. */
 		*buf[0] = usbdfu_state;
 		*len = 1;
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
 
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 int main(void)

--- a/examples/stm32/f1/stm32-h107/usb_simple/usb_simple.c
+++ b/examples/stm32/f1/stm32-h107/usb_simple/usb_simple.c
@@ -77,8 +77,10 @@ const char *usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int simple_control_callback(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+simple_control_callback(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)buf;
 	(void)len;
@@ -86,14 +88,14 @@ static int simple_control_callback(usbd_device *usbd_dev, struct usb_setup_data 
 	(void)usbd_dev;
 
 	if (req->bmRequestType != 0x40)
-		return 0; /* Only accept vendor request. */
+		return USBD_REQ_NOTSUPP; /* Only accept vendor request. */
 
 	if (req->wValue & 1)
 		gpio_set(GPIOC, GPIO6);
 	else
 		gpio_clear(GPIOC, GPIO6);
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
 int main(void)

--- a/examples/stm32/f1/stm32-maple/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/stm32-maple/usb_cdcacm/cdcacm.c
@@ -167,8 +167,10 @@ static const char *usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+cdcacm_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf,
+		uint16_t *len, usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)buf;
@@ -193,14 +195,14 @@ static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		local_buf[8] = req->wValue & 3;
 		local_buf[9] = 0;
 		// usbd_ep_write_packet(0x83, buf, 10);
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case USB_CDC_REQ_SET_LINE_CODING:
 		if (*len < sizeof(struct usb_cdc_line_coding))
-			return 0;
-		return 1;
+			return USBD_REQ_NOTSUPP;
+		return USBD_REQ_HANDLED;
 	}
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)

--- a/examples/stm32/f3/stm32f3-discovery/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f3/stm32f3-discovery/usb_cdcacm/cdcacm.c
@@ -166,8 +166,10 @@ static const char *usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *req, uint8_t **buf,
-		uint16_t *len, void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+static enum usbd_request_return_codes
+cdcacm_control_request(usbd_device *usbd_dev,
+		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)buf;
@@ -192,14 +194,14 @@ static int cdcacm_control_request(usbd_device *usbd_dev, struct usb_setup_data *
 		local_buf[8] = req->wValue & 3;
 		local_buf[9] = 0;
 		// usbd_ep_write_packet(0x83, buf, 10);
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case USB_CDC_REQ_SET_LINE_CODING:
 		if (*len < sizeof(struct usb_cdc_line_coding))
-			return 0;
-		return 1;
+			return USBD_REQ_NOTSUPP;
+		return USBD_REQ_HANDLED;
 	}
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)

--- a/examples/stm32/f4/stm32f4-discovery/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f4/stm32f4-discovery/usb_cdcacm/cdcacm.c
@@ -167,9 +167,10 @@ static const char * usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int cdcacm_control_request(usbd_device *usbd_dev,
+static enum usbd_request_return_codes
+cdcacm_control_request(usbd_device *usbd_dev,
 	struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-	void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+	usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)buf;
@@ -182,16 +183,16 @@ static int cdcacm_control_request(usbd_device *usbd_dev,
 		 * even though it's optional in the CDC spec, and we don't
 		 * advertise it in the ACM functional descriptor.
 		 */
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case USB_CDC_REQ_SET_LINE_CODING:
 		if (*len < sizeof(struct usb_cdc_line_coding)) {
-			return 0;
+			return USBD_REQ_NOTSUPP;
 		}
 
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)

--- a/examples/stm32/f4/stm32f429i-discovery/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f4/stm32f429i-discovery/usb_cdcacm/cdcacm.c
@@ -168,9 +168,10 @@ static const char *usb_strings[] = {
 /* Buffer to be used for control requests. */
 uint8_t usbd_control_buffer[128];
 
-static int cdcacm_control_request(usbd_device *usbd_dev,
+static enum usbd_request_return_codes
+cdcacm_control_request(usbd_device *usbd_dev,
 	struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-	void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req))
+	usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)buf;
@@ -183,16 +184,16 @@ static int cdcacm_control_request(usbd_device *usbd_dev,
 		 * even though it's optional in the CDC spec, and we don't
 		 * advertise it in the ACM functional descriptor.
 		 */
-		return 1;
+		return USBD_REQ_HANDLED;
 		}
 	case USB_CDC_REQ_SET_LINE_CODING:
 		if (*len < sizeof(struct usb_cdc_line_coding)) {
-			return 0;
+			return USBD_REQ_NOTSUPP;
 		}
 
-		return 1;
+		return USBD_REQ_HANDLED;
 	}
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)

--- a/examples/tiva/lm4f/stellaris-ek-lm4f120xl/usb_to_serial_cdcacm/usb_cdcacm.c
+++ b/examples/tiva/lm4f/stellaris-ek-lm4f120xl/usb_to_serial_cdcacm/usb_cdcacm.c
@@ -173,12 +173,10 @@ usbd_device *acm_dev;
 uint8_t usbd_control_buffer[128];
 extern usbd_driver lm4f_usb_driver;
 
-static int cdcacm_control_request(usbd_device * usbd_dev,
-				  struct usb_setup_data *req, uint8_t ** buf,
-				  uint16_t * len,
-				  void (**complete) (usbd_device * usbd_dev,
-						     struct usb_setup_data *
-						     req))
+static enum usbd_request_return_codes
+cdcacm_control_request(usbd_device * usbd_dev,
+		struct usb_setup_data *req, uint8_t ** buf, uint16_t * len,
+		usbd_control_complete_callback *complete)
 {
 	uint8_t dtr, rts;
 
@@ -199,13 +197,13 @@ static int cdcacm_control_request(usbd_device * usbd_dev,
 
 			glue_set_line_state_cb(dtr, rts);
 
-			return 1;
+			return USBD_REQ_HANDLED;
 		}
 	case USB_CDC_REQ_SET_LINE_CODING:{
 			struct usb_cdc_line_coding *coding;
 
 			if (*len < sizeof(struct usb_cdc_line_coding))
-				return 0;
+				return USBD_REQ_NOTSUPP;
 
 			coding = (struct usb_cdc_line_coding *)*buf;
 			return glue_set_line_coding_cb(coding->dwDTERate,
@@ -214,7 +212,7 @@ static int cdcacm_control_request(usbd_device * usbd_dev,
 						       coding->bCharFormat);
 		}
 	}
-	return 0;
+	return USBD_REQ_NOTSUPP;
 }
 
 static void cdcacm_data_rx_cb(usbd_device * usbd_dev, uint8_t ep)

--- a/examples/tiva/lm4f/stellaris-ek-lm4f120xl/usb_to_serial_cdcacm/usb_to_serial_cdcacm.c
+++ b/examples/tiva/lm4f/stellaris-ek-lm4f120xl/usb_to_serial_cdcacm/usb_to_serial_cdcacm.c
@@ -104,7 +104,8 @@ void glue_set_line_state_cb(uint8_t dtr, uint8_t rts)
 	uart_set_ctl_line_state(dtr, rts);
 }
 
-int glue_set_line_coding_cb(uint32_t baud, uint8_t databits,
+enum usbd_request_return_codes
+glue_set_line_coding_cb(uint32_t baud, uint8_t databits,
 			    enum usb_cdc_line_coding_bParityType cdc_parity,
 			    enum usb_cdc_line_coding_bCharFormat cdc_stopbits)
 {
@@ -112,7 +113,7 @@ int glue_set_line_coding_cb(uint32_t baud, uint8_t databits,
 	uint8_t uart_stopbits;
 
 	if (databits < 5 || databits > 8)
-		return 0;
+		return USBD_REQ_NOTSUPP;
 
 	switch (cdc_parity) {
 	case USB_CDC_NO_PARITY:
@@ -125,7 +126,7 @@ int glue_set_line_coding_cb(uint32_t baud, uint8_t databits,
 		parity = UART_PARITY_EVEN;
 		break;
 	default:
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	}
 
 	switch (cdc_stopbits) {
@@ -136,7 +137,7 @@ int glue_set_line_coding_cb(uint32_t baud, uint8_t databits,
 		uart_stopbits = 2;
 		break;
 	default:
-		return 0;
+		return USBD_REQ_NOTSUPP;
 	}
 
 	/* Disable the UART while we mess with its settings */
@@ -149,7 +150,7 @@ int glue_set_line_coding_cb(uint32_t baud, uint8_t databits,
 	/* Back to work. */
 	uart_enable(UART1);
 
-	return 1;
+	return USBD_REQ_HANDLED;
 }
 
 void glue_send_data_cb(uint8_t * buf, uint16_t len)

--- a/examples/tiva/lm4f/stellaris-ek-lm4f120xl/usb_to_serial_cdcacm/usb_to_serial_cdcacm.h
+++ b/examples/tiva/lm4f/stellaris-ek-lm4f120xl/usb_to_serial_cdcacm/usb_to_serial_cdcacm.h
@@ -24,6 +24,7 @@
 
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/lm4f/gpio.h>
+#include <libopencm3/usb/usbd.h>
 #include <libopencm3/usb/cdc.h>
 
 /* =============================================================================
@@ -58,7 +59,8 @@ void cdcacm_send_data(uint8_t *buf, uint16_t len);
  * ---------------------------------------------------------------------------*/
 void glue_data_received_cb(uint8_t *buf, uint16_t len);
 void glue_set_line_state_cb(uint8_t dtr, uint8_t rts);
-int glue_set_line_coding_cb(uint32_t baud, uint8_t databits,
+enum usbd_request_return_codes
+glue_set_line_coding_cb(uint32_t baud, uint8_t databits,
 			    enum usb_cdc_line_coding_bParityType cdc_parity,
 			    enum usb_cdc_line_coding_bCharFormat cdc_stopbits);
 void glue_send_data_cb(uint8_t *buf, uint16_t len);


### PR DESCRIPTION
fix examples for incomming PR libopencm3#497.