### PR TITLE
Add support for flashing with stm32flash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ to the flash target.
     cd examples/stm32/f1/stm32vl-discovery/miniblink
     make flash STLINK_PORT=:4242
 
+If you're using stm32flash to talk to an ST loader over a serial port,
+you can provide STM32\_PORT:
+
+    cd examples/stm32/f1/stm32vl-discovery/miniblink
+    make flash STM32_PORT=/dev/ttyACM0
+
 ## Flashing Manually
 You can also flash manually. Using a miriad of different tools depending on
 your setup. Here are a few examples.

--- a/examples/Makefile.rules
+++ b/examples/Makefile.rules
@@ -201,6 +201,7 @@ styleclean: $(STYLECHECKFILES:=.styleclean)
 ifeq ($(STLINK_PORT),)
 ifeq ($(BMP_PORT),)
 ifeq ($(OOCD_SERIAL),)
+ifeq ($(STM32_PORT),)
 %.flash: %.hex
 	@printf "  FLASH   $<\n"
 	@# IMPORTANT: Don't use "resume", only "reset" will work correctly!
@@ -210,6 +211,11 @@ ifeq ($(OOCD_SERIAL),)
 		    -c "flash write_image erase $(*).hex" \
 		    -c "reset" \
 		    -c "shutdown" $(NULL)
+else
+%.flash: %.bin
+	@printf "  FLASH   $<\n"
+	stm32flash -g 0x8000000 -b 230400 -w $(*).bin $(STM32_PORT)
+endif
 else
 %.flash: %.hex
 	@printf "  FLASH   $<\n"


### PR DESCRIPTION
With this, you can flash with simple USB<->Serial adapter, no st-link,
jtag, etc. needed. The sources I use are part of
git@github.com:rogerclarkmelbourne/Arduino_STM32.git.