### PR TITLE
Add example blink project for nucleo-f401re board

### DIFF
--- a/examples/stm32/f4/nucleo-f401re/blink/Makefile
+++ b/examples/stm32/f4/nucleo-f401re/blink/Makefile
@@ -1,8 +1,6 @@
 ##
 ## This file is part of the libopencm3 project.
 ##
-## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
-##
 ## This library is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU Lesser General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or

--- a/examples/stm32/f4/nucleo-f401re/blink/Makefile
+++ b/examples/stm32/f4/nucleo-f401re/blink/Makefile
@@ -1,0 +1,25 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = blink
+
+LDSCRIPT = ../nucleo-f401re.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f4/nucleo-f401re/blink/README.md
+++ b/examples/stm32/f4/nucleo-f401re/blink/README.md
@@ -1,0 +1,10 @@
+# README
+
+This is the smallest-possible example program using libopencm3.
+
+It's intended for the ST Nucleo-F401RE eval board. It should blink
+the GREEN LED on the board.
+
+## Board connections
+
+*none required*

--- a/examples/stm32/f4/nucleo-f401re/blink/blink.c
+++ b/examples/stm32/f4/nucleo-f401re/blink/blink.c
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (c) 2015 Chuck McManis <cmcmanis@mcmanis.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+static void gpio_setup(void)
+{
+	/* Enable GPIOA clock. */
+	/* Manually: */
+	/*RCC_AHB1ENR |= RCC_AHB1ENR_IOPAEN; */
+	/* Using API functions: */
+	rcc_periph_clock_enable(RCC_GPIOA);
+
+	/* Set GPIO5 (in GPIO port A) to 'output push-pull'. */
+	/* Manually: */
+	/*GPIOA_CRH = (GPIO_CNF_OUTPUT_PUSHPULL << (((8 - 8) * 4) + 2)); */
+	/*GPIOA_CRH |= (GPIO_MODE_OUTPUT_2_MHZ << ((8 - 8) * 4)); */
+	/* Using API functions: */
+	gpio_mode_setup(GPIOA, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO5);
+}
+
+int main(void)
+{
+	int i;
+
+	gpio_setup();
+
+	/* Blink the LED (PC8) on the board. */
+	while (1) {
+		/* Manually: */
+		/* GPIOA_BSRR = GPIO5; */		/* LED off */
+		/* for (i = 0; i < 1000000; i++) */	/* Wait a bit. */
+		/*	__asm__("nop"); */
+		/* GPIOA_BRR = GPIO5; */		/* LED on */
+		/* for (i = 0; i < 1000000; i++) */	/* Wait a bit. */
+		/*	__asm__("nop"); */
+
+		/* Using API functions gpio_set()/gpio_clear(): */
+		/* gpio_set(GPIOA, GPIO5); */	/* LED off */
+		/* for (i = 0; i < 1000000; i++) */	/* Wait a bit. */
+		/*	__asm__("nop"); */
+		/* gpio_clear(GPIOA, GPIO5); */	/* LED on */
+		/* for (i = 0; i < 1000000; i++) */	/* Wait a bit. */
+		/*	__asm__("nop"); */
+
+		/* Using API function gpio_toggle(): */
+		gpio_toggle(GPIOA, GPIO5);	/* LED on/off */
+		for (i = 0; i < 1000000; i++) {	/* Wait a bit. */
+			__asm__("nop");
+		}
+	}
+
+	return 0;
+}

--- a/examples/stm32/f4/nucleo-f401re/blink/blink.c
+++ b/examples/stm32/f4/nucleo-f401re/blink/blink.c
@@ -1,10 +1,6 @@
 /*
  * This file is part of the libopencm3 project.
  *
- * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
- * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
- * Copyright (c) 2015 Chuck McManis <cmcmanis@mcmanis.com>
- *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/examples/stm32/f4/nucleo-f401re/nucleo-f401re.ld
+++ b/examples/stm32/f4/nucleo-f401re/nucleo-f401re.ld
@@ -1,9 +1,6 @@
 /*
  * This file is part of the libopencm3 project.
  *
- * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
- * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
- *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -18,7 +15,7 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* Linker script for Nucleo F411RE  (STM32F411RE, 512K flash, 128K RAM). */
+/* Linker script for Nucleo F401RE  (STM32F401RE, 512K flash, 96K RAM). */
 
 /* Define memory regions. */
 MEMORY

--- a/examples/stm32/f4/nucleo-f401re/nucleo-f401re.ld
+++ b/examples/stm32/f4/nucleo-f401re/nucleo-f401re.ld
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for Nucleo F411RE  (STM32F411RE, 512K flash, 128K RAM). */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 512K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 96K
+}
+
+/* Include the common ld script. */
+INCLUDE libopencm3_stm32f4.ld
+


### PR DESCRIPTION
This is the same code as the nucleo-f411re board. I just modified the linker configuration to support the f401re board.
