### PR TITLE
Makefile.include: don't override DEFS

### DIFF
--- a/examples/lpc/lpc13xx/Makefile.include
+++ b/examples/lpc/lpc13xx/Makefile.include
@@ -19,7 +19,7 @@
 ##
 
 LIBNAME		= opencm3_lpc13xx
-DEFS		= -DLPC13XX
+DEFS		+= -DLPC13XX
 
 FP_FLAGS	?= -msoft-float
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m3 $(FP_FLAGS) -mfix-cortex-m3-ldrd

--- a/examples/lpc/lpc17xx/Makefile.include
+++ b/examples/lpc/lpc17xx/Makefile.include
@@ -20,7 +20,7 @@
 
 
 LIBNAME		= opencm3_lpc17xx
-DEFS		= -DLPC17XX
+DEFS		+= -DLPC17XX
 
 FP_FLAGS	?= -msoft-float
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m3 $(FP_FLAGS) -mfix-cortex-m3-ldrd

--- a/examples/lpc/lpc43xx/Makefile.include
+++ b/examples/lpc/lpc43xx/Makefile.include
@@ -22,7 +22,7 @@
 
 
 LIBNAME		= opencm3_lpc43xx
-DEFS		= -DLPC43XX
+DEFS		+= -DLPC43XX
 
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m4 $(FP_FLAGS)

--- a/examples/stm32/f0/Makefile.include
+++ b/examples/stm32/f0/Makefile.include
@@ -19,7 +19,7 @@
 ##
 
 LIBNAME		= opencm3_stm32f0
-DEFS		= -DSTM32F0
+DEFS		+= -DSTM32F0
 
 FP_FLAGS	?= -msoft-float
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m0 $(FP_FLAGS)

--- a/examples/stm32/f1/Makefile.include
+++ b/examples/stm32/f1/Makefile.include
@@ -19,7 +19,7 @@
 ##
 
 LIBNAME		= opencm3_stm32f1
-DEFS		= -DSTM32F1
+DEFS		+= -DSTM32F1
 
 FP_FLAGS	?= -msoft-float
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m3 $(FP_FLAGS) -mfix-cortex-m3-ldrd

--- a/examples/stm32/f2/Makefile.include
+++ b/examples/stm32/f2/Makefile.include
@@ -20,7 +20,7 @@
 ##
 
 LIBNAME		= opencm3_stm32f2
-DEFS		= -DSTM32F2
+DEFS		+= -DSTM32F2
 
 FP_FLAGS	?= -msoft-float
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m3 $(FP_FLAGS) -mfix-cortex-m3-ldrd

--- a/examples/stm32/f3/Makefile.include
+++ b/examples/stm32/f3/Makefile.include
@@ -20,7 +20,7 @@
 ##
 
 LIBNAME		= opencm3_stm32f3
-DEFS		= -DSTM32F3
+DEFS		+= -DSTM32F3
 
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m4 $(FP_FLAGS)

--- a/examples/stm32/f4/Makefile.include
+++ b/examples/stm32/f4/Makefile.include
@@ -20,7 +20,7 @@
 ##
 
 LIBNAME		= opencm3_stm32f4
-DEFS		= -DSTM32F4
+DEFS		+= -DSTM32F4
 
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m4 $(FP_FLAGS)

--- a/examples/stm32/l0/Makefile.include
+++ b/examples/stm32/l0/Makefile.include
@@ -19,7 +19,7 @@
 ##
 
 LIBNAME		= opencm3_stm32l0
-DEFS		= -DSTM32L0
+DEFS		+= -DSTM32L0
 
 FP_FLAGS	?= -msoft-float
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m0plus $(FP_FLAGS)

--- a/examples/stm32/l1/Makefile.include
+++ b/examples/stm32/l1/Makefile.include
@@ -19,7 +19,7 @@
 ##
 
 LIBNAME		= opencm3_stm32l1
-DEFS		= -DSTM32L1
+DEFS		+= -DSTM32L1
 
 FP_FLAGS	?= -msoft-float
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m3 $(FP_FLAGS) -mfix-cortex-m3-ldrd

--- a/examples/tiva/lm3s/Makefile.include
+++ b/examples/tiva/lm3s/Makefile.include
@@ -19,7 +19,7 @@
 ##
 
 LIBNAME		= opencm3_lm3s
-DEFS		= -DLM3S
+DEFS		+= -DLM3S
 
 FP_FLAGS	?= -msoft-float
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m3 $(FP_FLAGS)

--- a/examples/tiva/lm4f/Makefile.include
+++ b/examples/tiva/lm4f/Makefile.include
@@ -20,7 +20,7 @@
 ##
 
 LIBNAME		= opencm3_lm4f
-DEFS		= -DLM4F
+DEFS		+= -DLM4F
 
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m4 $(FP_FLAGS)

--- a/examples/vf6xx/colibri-vf61/Makefile.include
+++ b/examples/vf6xx/colibri-vf61/Makefile.include
@@ -21,7 +21,7 @@
 ##
 
 LIBNAME		= opencm3_vf6xx
-DEFS		= -DVF6XX
+DEFS		+= -DVF6XX
 
 FP_FLAGS	?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
 ARCH_FLAGS	= -mthumb -mcpu=cortex-m4 $(FP_FLAGS)


### PR DESCRIPTION
The usart-semihosting example sets DEFS, thus overriding DEFS breaks it