### PR TITLE
stm32f103: fix all usb driver

### DIFF
--- a/examples/stm32/f1/other/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/other/usb_cdcacm/cdcacm.c
@@ -244,7 +244,7 @@ int main(void)
 
 	gpio_set_mode(GPIOA, GPIO_MODE_INPUT, 0, GPIO15);
 
-	usbd_dev = usbd_init(&stm32f107_usb_driver, &dev, &config, usb_strings, 3, usbd_control_buffer, sizeof(usbd_control_buffer));
+	usbd_dev = usbd_init(&st_usbfs_v1_usb_driver, &dev, &config, usb_strings, 3, usbd_control_buffer, sizeof(usbd_control_buffer));
 	usbd_register_set_config_callback(usbd_dev, cdcacm_set_config);
 
 	gpio_set(GPIOA, GPIO15);

--- a/examples/stm32/f1/other/usb_dfu/usbdfu.c
+++ b/examples/stm32/f1/other/usb_dfu/usbdfu.c
@@ -269,7 +269,7 @@ int main(void)
 
 	rcc_periph_clock_enable(RCC_OTGFS);
 
-	usbd_dev = usbd_init(&stm32f107_usb_driver, &dev, &config, usb_strings, 4, usbd_control_buffer, sizeof(usbd_control_buffer));
+	usbd_dev = usbd_init(&st_usbfs_v1_usb_driver, &dev, &config, usb_strings, 4, usbd_control_buffer, sizeof(usbd_control_buffer));
 	usbd_register_set_config_callback(usbd_dev, usbdfu_set_config);
 
 	gpio_set(GPIOA, GPIO15);

--- a/examples/stm32/f1/other/usb_hid/usbhid.c
+++ b/examples/stm32/f1/other/usb_hid/usbhid.c
@@ -285,7 +285,7 @@ int main(void)
 	AFIO_MAPR |= AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_ON;
 	gpio_set_mode(GPIOA, GPIO_MODE_INPUT, 0, GPIO15);
 
-	usbd_dev = usbd_init(&stm32f107_usb_driver, &dev_descr, &config, usb_strings, 3, usbd_control_buffer, sizeof(usbd_control_buffer));
+	usbd_dev = usbd_init(&st_usbfs_v1_usb_driver, &dev_descr, &config, usb_strings, 3, usbd_control_buffer, sizeof(usbd_control_buffer));
 	usbd_register_set_config_callback(usbd_dev, hid_set_config);
 
 	gpio_set(GPIOA, GPIO15);

--- a/examples/stm32/f1/stm32-h103/usb_dfu/usbdfu.c
+++ b/examples/stm32/f1/stm32-h103/usb_dfu/usbdfu.c
@@ -267,7 +267,7 @@ int main(void)
 		      GPIO_CNF_OUTPUT_PUSHPULL, GPIO11);
 	gpio_set(GPIOC, GPIO11);
 
-	usbd_dev = usbd_init(&stm32f107_usb_driver, &dev, &config, usb_strings, 4, usbd_control_buffer, sizeof(usbd_control_buffer));
+	usbd_dev = usbd_init(&st_usbfs_v1_usb_driver, &dev, &config, usb_strings, 4, usbd_control_buffer, sizeof(usbd_control_buffer));
 	usbd_register_set_config_callback(usbd_dev, usbdfu_set_config);
 
 	gpio_clear(GPIOC, GPIO11);

--- a/examples/stm32/f1/stm32-h103/usb_hid/usbhid.c
+++ b/examples/stm32/f1/stm32-h103/usb_hid/usbhid.c
@@ -286,7 +286,7 @@ int main(void)
 	gpio_set_mode(GPIOC, GPIO_MODE_OUTPUT_2_MHZ,
 		      GPIO_CNF_OUTPUT_PUSHPULL, GPIO11);
 
-	usbd_dev = usbd_init(&stm32f107_usb_driver, &dev, &config, usb_strings, 3, usbd_control_buffer, sizeof(usbd_control_buffer));
+	usbd_dev = usbd_init(&st_usbfs_v1_usb_driver, &dev, &config, usb_strings, 3, usbd_control_buffer, sizeof(usbd_control_buffer));
 	usbd_register_set_config_callback(usbd_dev, hid_set_config);
 
 	for (i = 0; i < 0x80000; i++)

--- a/examples/stm32/f1/stm32-h103/usb_iap/usbiap.c
+++ b/examples/stm32/f1/stm32-h103/usb_iap/usbiap.c
@@ -268,7 +268,7 @@ int main(void)
 	AFIO_MAPR |= AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_ON;
 	gpio_set_mode(GPIOA, GPIO_MODE_INPUT, 0, GPIO15);
 
-	usbd_dev = usbd_init(&stm32f107_usb_driver, &dev, &config, usb_strings, 4, usbd_control_buffer, sizeof(usbd_control_buffer));
+	usbd_dev = usbd_init(&st_usbfs_v1_usb_driver, &dev, &config, usb_strings, 4, usbd_control_buffer, sizeof(usbd_control_buffer));
 	usbd_register_set_config_callback(usbd_dev, usbdfu_set_config);
 
 	gpio_set(GPIOA, GPIO15);

--- a/examples/stm32/f1/stm32-maple/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/stm32-maple/usb_cdcacm/cdcacm.c
@@ -257,7 +257,7 @@ int main(void)
 	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ,
 		      GPIO_CNF_OUTPUT_PUSHPULL, GPIO5);
 
-	usbd_dev = usbd_init(&stm32f107_usb_driver, &dev, &config, usb_strings, 3, usbd_control_buffer, sizeof(usbd_control_buffer));
+	usbd_dev = usbd_init(&st_usbfs_v1_usb_driver, &dev, &config, usb_strings, 3, usbd_control_buffer, sizeof(usbd_control_buffer));
 	usbd_register_set_config_callback(usbd_dev, cdcacm_set_config);
 
 	for (i = 0; i < 0x800000; i++)

--- a/examples/stm32/f1/waveshare-open103r/usbserial/usbserial.c
+++ b/examples/stm32/f1/waveshare-open103r/usbserial/usbserial.c
@@ -251,7 +251,7 @@ int main(void)
 
   AFIO_MAPR |= AFIO_MAPR_SWJ_CFG_JTAG_OFF_SW_ON;
 
-  usbd_dev = usbd_init(&stm32f107_usb_driver,
+  usbd_dev = usbd_init(&st_usbfs_v1_usb_driver,
 		       &dev,
 		       &config,
 		       usb_strings,


### PR DESCRIPTION
STM32F103 's USB examples has broken by use STM32F107 's driver. I have fixed up this.