### PR TITLE
stm32f4-discovery: correct README

### DIFF
--- a/examples/stm32/f4/stm32f4-discovery/README.md
+++ b/examples/stm32/f4/stm32f4-discovery/README.md
@@ -7,6 +7,6 @@ accelerometer.
 
 http://www.st.com/web/catalog/tools/FM116/SC959/SS1532/PF252419
 
-The later stm32f4 discovery boards, for the f401, MB91115B and for the f429i,
+The later stm32f4 discovery boards, for the f401, MB1115B and for the f429i,
 MB1075B will not work as is with these demos, but they should only need minor
 tweaking for pin configurations.


### PR DESCRIPTION
STM32F401 Discovery is labelled MB1115B, not MB91115B.

Mine was labelled MB1115B and the one on http://www.st.com/stm32f401discovery also is.

It took me some time to figure out what is happening :smile: 