### PR TITLE
examples/tiva/lm4f: Use correct openocd interface

### DIFF
--- a/examples/tiva/lm4f/Makefile.include
+++ b/examples/tiva/lm4f/Makefile.include
@@ -31,7 +31,7 @@ ARCH_FLAGS	= -mthumb -mcpu=cortex-m4 $(FP_FLAGS)
 # Support for ICDI is available starting with openocd 0.7.0
 
 OOCD		?= openocd
-OOCD_INTERFACE	?= flossjtag
+OOCD_INTERFACE	?= ti-icdi
 OOCD_BOARD	?= ek-lm4f120xl
 
 ################################################################################


### PR DESCRIPTION
I'd love to meet the person who managed to use flossjtag interface
with a Stellaris board, but until we can meet, use the correct
interface, which is ti-icdi. Note that this setting is redundant,
since the board config file already specifies the correct interface;
however, OOCD_INTERFACE variable cannot be empty, by virtue of how
higher-level makefiles are written.