### PR TITLE
Add examples for ST Nucleo-F303RE

### DIFF
--- a/examples/stm32/f3/nucleo-f303re/Makefile.include
+++ b/examples/stm32/f3/nucleo-f303re/Makefile.include
@@ -1,0 +1,34 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2010 Piotr Esden-Tempski <piotr@esden.net>
+## Copyright (C) 2011 Fergus Noble <fergusnoble@gmail.com>
+## Copyright (C) 2016 Josh Myer <josh@joshisanerd.com>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+
+LDSCRIPT ?= ../st-nucleo-f303re.ld
+
+
+################################################################################
+# OpenOCD specific variables
+
+OOCD_INTERFACE	?= stlink-v2-1
+OOCD_BOARD	?= st_nucleo_f3  # NB: not exact, but close enough.
+
+
+include ../../Makefile.include

--- a/examples/stm32/f3/nucleo-f303re/adc/Makefile
+++ b/examples/stm32/f3/nucleo-f303re/adc/Makefile
@@ -1,0 +1,23 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2016 Josh Myer <josh@joshisanerd.com>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = adc
+
+include ../Makefile.include

--- a/examples/stm32/f3/nucleo-f303re/adc/README.md
+++ b/examples/stm32/f3/nucleo-f303re/adc/README.md
@@ -1,0 +1,11 @@
+# README
+
+This makes an LED bar-graph of an analog input.  It's intended for the
+ST Nucleo-F303RE devboard, with the LEDs attached to the Arduino
+header pins, going from D13 to D6.  The analog input is sampled from
+the Arduino header analog input A0.  It also prints the output on the
+serial port, which is available as an ACM device on many OSes
+(/dev/ttyACM on Linux, etc).  If you solder SB62 and SB63, you can get
+the serial output on the Arduino's usual TX/RX pins as well.
+
+

--- a/examples/stm32/f3/nucleo-f303re/adc/adc.c
+++ b/examples/stm32/f3/nucleo-f303re/adc/adc.c
@@ -1,0 +1,226 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Modified by Fernando Cortes <fermando.corcam@gmail.com>
+ * modified by Guillermo Rivera <memogrg@gmail.com>
+ * Copyright (C) 2016 Josh Myer <josh@joshisanerd.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/adc.h>
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/stm32/gpio.h>
+
+
+/* This assumes you've put LEDs on the Arduino header, D13~D6.
+ *
+ * Also, put an analog input into the Arduino A0 pin.
+ */
+
+/* Arduino pin mapping */
+#define D13 GPIOA, GPIO5
+#define D12 GPIOA, GPIO6
+#define D11 GPIOA, GPIO7
+#define D10 GPIOB, GPIO6
+#define  D9 GPIOC, GPIO7
+#define  D8 GPIOA, GPIO9
+#define  D7 GPIOA, GPIO8
+#define  D6 GPIOB, GPIO10
+
+/* Other arduino pins that may matter:
+ *  D1 - PA2 (Serial TX, nucleo -> PC)
+ *  D0 - PA3 (Serial RX, PC -> nucleo)
+ *  A0 - PA0
+ */
+
+/* Final port masks for GPIO:
+ * PA: 5-9
+ * PB: 6,10
+ * PC: 7
+ */
+
+#define MASKA GPIO5 | GPIO6 | GPIO7 | GPIO8 | GPIO9
+#define MASKB GPIO6 | GPIO10
+#define MASKC GPIO7
+
+
+static void adc_setup(void)
+{
+	uint8_t channel_array[16];
+	uint32_t i;
+
+	rcc_periph_clock_enable(RCC_ADC12);
+	rcc_periph_clock_enable(RCC_GPIOA);
+
+	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO0);
+	adc_off(ADC1);
+	adc_set_clk_prescale(ADC_CCR_CKMODE_DIV2);
+	adc_set_single_conversion_mode(ADC1);
+	adc_disable_external_trigger_regular(ADC1);
+	adc_set_right_aligned(ADC1);
+
+	/* We want to read the temperature sensor, so we have to enable it. */
+	adc_enable_temperature_sensor();
+
+	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR1_SMP_61DOT5CYC);
+
+
+	/* Set up an array of channels to sample from, all ADC1/A0 */
+	for (i = 0; i < 16; i++) {
+		channel_array[i] = 1;
+	}
+	channel_array[0] = 1; /* ADC1_IN1 (PA0) */
+
+	adc_set_regular_sequence(ADC1, 1, channel_array);
+	adc_set_resolution(ADC1, ADC_CFGR_RES_12_BIT);
+	adc_power_on(ADC1);
+
+	/* Wait for ADC starting up. */
+	for (i = 0; i < 800000; i++) {
+		__asm__("nop");
+	}
+
+}
+
+static void usart_setup(void)
+{
+	/* Enable clocks for GPIO port A (for GPIO_USART2_TX) and USART2. */
+	rcc_periph_clock_enable(RCC_USART2);
+	rcc_periph_clock_enable(RCC_GPIOA);
+
+	/* Setup GPIO pin GPIO_USART2_TX/GPIO9 on GPIO port A for transmit. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2 | GPIO3);
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2 | GPIO3);
+
+	/* Setup UART parameters. */
+	usart_set_baudrate(USART2, 115200);
+	usart_set_databits(USART2, 8);
+	usart_set_stopbits(USART2, USART_STOPBITS_1);
+	usart_set_mode(USART2, USART_MODE_TX_RX);
+	usart_set_parity(USART2, USART_PARITY_NONE);
+	usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
+
+	/* Finally enable the USART. */
+	usart_enable(USART2);
+}
+
+static void gpio_setup(void)
+{
+	rcc_periph_clock_enable(RCC_GPIOA);
+	gpio_mode_setup(GPIOA, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, MASKA);
+
+	rcc_periph_clock_enable(RCC_GPIOB);
+	gpio_mode_setup(GPIOB, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, MASKB);
+
+	rcc_periph_clock_enable(RCC_GPIOC);
+	gpio_mode_setup(GPIOC, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, MASKC);
+}
+
+static void my_usart_print_int(uint32_t usart, int16_t value)
+{
+	int8_t i;
+	int8_t nr_digits = 0;
+	char buffer[25];
+
+	if (value < 0) {
+		usart_send_blocking(usart, '-');
+		value = value * -1;
+	}
+
+	if (value == 0) {
+		usart_send_blocking(usart, '0');
+	}
+
+	while (value > 0) {
+		buffer[nr_digits++] = "0123456789"[value % 10];
+		value /= 10;
+	}
+
+	for (i = nr_digits-1; i >= 0; i--) {
+		usart_send_blocking(usart, buffer[i]);
+	}
+
+	usart_send_blocking(usart, '\r');
+	usart_send_blocking(usart, '\n');
+}
+
+static void my_usart_print_str(uint32_t usart, char *s)
+{
+	while (*s) {
+		usart_send_blocking(usart, *s);
+		s++;
+	}
+}
+
+static void clock_setup(void)
+{
+	rcc_clock_setup_hsi(&rcc_hsi_8mhz[RCC_CLOCK_64MHZ]);
+}
+
+static void blit_fill(uint8_t reading)
+{
+	int i;
+	int max_bit = 0;
+
+	for (i = 0; i < 8; i++) {
+		if (reading > 1<<i) {
+			max_bit = i;
+		}
+	}
+
+	/* Turn all LEDs off */
+	gpio_clear(GPIOA, MASKA);
+	gpio_clear(GPIOB, MASKB);
+	gpio_clear(GPIOC, MASKC);
+
+	/* Turn on all LEDs below our level */
+	switch (max_bit) {
+	case 7: gpio_set(D13);
+	case 6: gpio_set(D12);
+	case 5: gpio_set(D11);
+	case 4: gpio_set(D10);
+	case 3: gpio_set( D9);
+	case 2: gpio_set( D8);
+	case 1: gpio_set( D7);
+	case 0: gpio_set( D6);
+	}
+
+}
+
+int main(void)
+{
+	volatile uint16_t temp;
+
+	clock_setup();
+	gpio_setup();
+	adc_setup();
+	usart_setup();
+
+	my_usart_print_str(USART2, "Starting up...\r\n");
+
+	while (1) {
+		adc_start_conversion_regular(ADC1);
+		while (!(adc_eoc(ADC1)));
+		temp = adc_read_regular(ADC1);
+		blit_fill(temp >> 4);
+		my_usart_print_int(USART2, temp);
+	}
+
+	return 0;
+}
+

--- a/examples/stm32/f3/nucleo-f303re/fancyblink/Makefile
+++ b/examples/stm32/f3/nucleo-f303re/fancyblink/Makefile
@@ -1,0 +1,24 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2016 Josh Myer <josh@joshisanerd.com>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = fancyblink
+
+include ../Makefile.include
+

--- a/examples/stm32/f3/nucleo-f303re/fancyblink/README.md
+++ b/examples/stm32/f3/nucleo-f303re/fancyblink/README.md
@@ -1,0 +1,7 @@
+# README
+
+This is a small example program using libopencm3.
+
+It's intended for the ST Nucleo-F303RE eval board. It should blink
+LEDs connected to the Arduino header, D6~D13.
+

--- a/examples/stm32/f3/nucleo-f303re/fancyblink/fancyblink.c
+++ b/examples/stm32/f3/nucleo-f303re/fancyblink/fancyblink.c
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Damjan Marion <damjan.marion@gmail.com>
+ * Copyright (C) 2011 Mark Panajotovic <marko@electrontube.org>
+ * Copyright (C) 2016 Josh Myer <josh@joshisanerd.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+/* This assumes you've put LEDs on the Arduino header, D13~D6. */
+
+
+/* Arduino header pin mapping: */
+#define D13 GPIOA, GPIO5
+#define D12 GPIOA, GPIO6
+#define D11 GPIOA, GPIO7
+#define D10 GPIOB, GPIO6
+#define  D9 GPIOC, GPIO7
+#define  D8 GPIOA, GPIO9
+#define  D7 GPIOA, GPIO8
+#define  D6 GPIOB, GPIO10
+
+
+/* Final port usage:
+ * PA: 5-9
+ * PB: 6,10
+ * PC: 7
+ */
+
+#define MASKA GPIO5 | GPIO6 | GPIO7 | GPIO8 | GPIO9
+#define MASKB GPIO6 | GPIO10
+#define MASKC GPIO7
+
+/* Set STM32 to 64 MHz. */
+static void clock_setup(void)
+{
+	rcc_clock_setup_hsi(&rcc_hsi_8mhz[RCC_CLOCK_64MHZ]);
+}
+
+static void gpio_setup(void)
+{
+	rcc_periph_clock_enable(RCC_GPIOA);
+	gpio_mode_setup(GPIOA, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, MASKA);
+
+	rcc_periph_clock_enable(RCC_GPIOB);
+	gpio_mode_setup(GPIOB, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, MASKB);
+
+	rcc_periph_clock_enable(RCC_GPIOC);
+	gpio_mode_setup(GPIOC, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, MASKC);
+}
+
+int main(void)
+{
+	int i;
+
+	clock_setup();
+	gpio_setup();
+
+	/* Set two LEDs for wigwag effect when toggling. */
+	gpio_set(D13);
+	gpio_set(D6);
+
+	/* Blink the LEDs (PD8, PD9, PD10 and PD11) on the board. */
+	while (1) {
+		/* Toggle LEDs. */
+		gpio_toggle(GPIOA, MASKA);
+		gpio_toggle(GPIOB, MASKB);
+		gpio_toggle(GPIOC, MASKC);
+		/* Wait a bit. */
+		for (i = 0; i < 1000000; i++) {
+			__asm__("nop");
+		}
+	}
+
+	return 0;
+}

--- a/examples/stm32/f3/nucleo-f303re/miniblink/Makefile
+++ b/examples/stm32/f3/nucleo-f303re/miniblink/Makefile
@@ -1,0 +1,24 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2016 Josh Myer <josh@joshisanerd.com>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = miniblink
+
+include ../Makefile.include
+

--- a/examples/stm32/f3/nucleo-f303re/miniblink/README.md
+++ b/examples/stm32/f3/nucleo-f303re/miniblink/README.md
@@ -1,0 +1,7 @@
+# README
+
+This is the smallest-possible example program using libopencm3.
+
+It's intended for the ST Nucleo-F303RE eval board. It should blink the
+green LED (D2) on the board.
+

--- a/examples/stm32/f3/nucleo-f303re/miniblink/miniblink.c
+++ b/examples/stm32/f3/nucleo-f303re/miniblink/miniblink.c
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Modified by Fernando Cortes <fermando.corcam@gmail.com>
+ * modified by Guillermo Rivera <memogrg@gmail.com>
+ * Modified by Josh Myer <josh@joshisanerd.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+static void gpio_setup(void)
+{
+	/* Enable GPIOE clock. */
+	rcc_periph_clock_enable(RCC_GPIOA);
+
+	/* Set GPIO12 (in GPIO port E) to 'output push-pull'. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO5);
+}
+
+int main(void)
+{
+	int i;
+
+	gpio_setup();
+
+	/* Blink the LED (PC8) on the board. */
+	while (1) {
+		/* Using API function gpio_toggle(): */
+		gpio_toggle(GPIOA, GPIO5);      /* LED on/off */
+		for (i = 0; i < 2000000; i++) { /* Wait a bit. */
+			__asm__("nop");
+		}
+
+	}
+
+	return 0;
+}

--- a/examples/stm32/f3/nucleo-f303re/st-nucleo-f303re.ld
+++ b/examples/stm32/f3/nucleo-f303re/st-nucleo-f303re.ld
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (C) 2016 Josh Myer <josh@joshisanerd.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for ST STM32F3NUCLEO-F303RE (STM32F303RE, 512K flash, 64K RAM */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx)  : ORIGIN = 0x08000000, LENGTH = 512K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
+}
+
+/* Include the common ld script. */
+INCLUDE libopencm3_stm32f3.ld
+

--- a/examples/stm32/f3/nucleo-f303re/usart/Makefile
+++ b/examples/stm32/f3/nucleo-f303re/usart/Makefile
@@ -1,0 +1,25 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+## Copyright (C) 2015 Chuck McManis <cmcmanis@mcmanis.com>
+## Copyright (C) 2016 Josh Myer <josh@joshisanerd.com>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = usart
+
+include ../Makefile.include
+

--- a/examples/stm32/f3/nucleo-f303re/usart/README.md
+++ b/examples/stm32/f3/nucleo-f303re/usart/README.md
@@ -1,0 +1,22 @@
+# README
+
+This example program sends repeating sequence of characters
+"0123456789" on USART2 on the ST Nucleo-F303RE eval board.
+
+The sending is done in a blocking way.
+
+Note that the Nucleo board exports the serial port as an ttyACM device
+on Linux or a COM port on Windows. On Linux, if you can locate the
+correct serial port as
+
+/dev/serial/by-id/usb-STMicroelectronics_STM32_STLink_066CFF515056805087171825-if02
+
+(note there will be differences based on the serial number of your
+board) this may also show up as /dev/ttyACM0 if it was the first
+serial port enumerated, if you have additional serial devices attached
+to the USB port of your system they may show up as additional
+ttyACM1/ttyACM2/... etc.
+
+Connect to the port using `screen /dev/ttyACM0 115200` where you
+replace the serial port with the one for your system.
+

--- a/examples/stm32/f3/nucleo-f303re/usart/usart.c
+++ b/examples/stm32/f3/nucleo-f303re/usart/usart.c
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (C) 2015 Chuck McManis <cmcmanis@mcmanis.com>
+ * Copyright (C) 2016 Josh Myer <josh@joshisanerd.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/usart.h>
+
+static void clock_setup(void)
+{
+	/* Enable GPIOD clock for LED & USARTs. */
+	rcc_periph_clock_enable(RCC_GPIOA);
+
+	/* Enable clocks for USART2. */
+	rcc_periph_clock_enable(RCC_USART2);
+}
+
+static void usart_setup(void)
+{
+	/* Setup USART2 parameters. */
+	usart_set_baudrate(USART2, 115200);
+	usart_set_databits(USART2, 8);
+	usart_set_stopbits(USART2, USART_STOPBITS_1);
+	usart_set_mode(USART2, USART_MODE_TX);
+	usart_set_parity(USART2, USART_PARITY_NONE);
+	usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
+
+	/* Finally enable the USART. */
+	usart_enable(USART2);
+}
+
+static void gpio_setup(void)
+{
+	/* Setup GPIO pin GPIO5 on GPIO port A for LED. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO5);
+
+	/* Setup GPIO pins for USART2. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2 | GPIO3);
+
+	/* Setup USART2 TX/RX pins as alternate function. */
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2 | GPIO3);
+}
+
+int main(void)
+{
+	int i, j = 0, c = 0;
+
+	clock_setup();
+	gpio_setup();
+	usart_setup();
+
+	/* Blink the LED (PA5) on the board with every transmitted byte. */
+	while (1) {
+		gpio_toggle(GPIOA, GPIO5);	/* LED on/off */
+		usart_send_blocking(USART2, c + '0'); /* USART2: Send byte. */
+		c = (c == 9) ? 0 : c + 1;	/* Increment c. */
+		if ((j++ % 80) == 0) {		/* Newline after line full. */
+			usart_send_blocking(USART2, '\r');
+			usart_send_blocking(USART2, '\n');
+		}
+		for (i = 0; i < 300000; i++) {	/* Wait a bit. */
+			__asm__("NOP");
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This adds some basic examples for the STM ST Nucleo-F303RE devboard.  This is a model of F3 chip that doesn't have examples here yet, so there's a new st-nucleo-f303re.ld file to allow using the full memory out-of-the-box.

ST moved a lot of stuff around on the dev board between Discovery and Nucleo, so blinking LEDs that are "together" requires many (ugly and grumpy-making) pin changes.  This sort of thing made it impractical to try and merge the changes down into the stm32f3-discovery directory.

I've run it through 'make stylecheck'; there are a few places it complains, but "fixing" them would either make the code not compile or markedly less legible.

Thanks in advance for any feedback on this PR.  I tried to read through a bunch of PRs and find the usual sticking points before submitting, but I may have missed things.  Sorry if there's an obvious problem that I overlooked, and thanks for taking the time to gatekeep for this library!\