### PR TITLE
[stm32f429i-discovery lcd-serial] example uses now real rgb565 colors

### DIFF
--- a/examples/stm32/f4/stm32f429i-discovery/lcd-serial/lcd-spi.c
+++ b/examples/stm32/f4/stm32f429i-discovery/lcd-serial/lcd-spi.c
@@ -93,14 +93,19 @@ static void lcd_command(uint8_t cmd, int delay, int n_args,
 static void
 lcd_command(uint8_t cmd, int delay, int n_args, const uint8_t *args)
 {
-	int i;
-
 	gpio_clear(GPIOC, GPIO2);	/* Select the LCD */
 	(void) spi_xfer(LCD_SPI, cmd);
 	if (n_args) {
 		gpio_set(GPIOD, GPIO13);	/* Set the D/CX pin */
-		for (i = 0; i < n_args; i++) {
-			(void) spi_xfer(LCD_SPI, *(args+i));
+		for (int i = 0; i < n_args; i++) {
+			if (cmd == 0x2c) { // if colors are being sent
+				// switch to little-endian to get real rgb565 colors
+				(void) spi_xfer(LCD_SPI, *(args+i+1));
+				(void) spi_xfer(LCD_SPI, *(args+i));
+				i++;
+			} else {
+				(void) spi_xfer(LCD_SPI, *(args+i));
+			}
 		}
 	}
 	gpio_set(GPIOC, GPIO2);		/* Turn off chip select */

--- a/examples/stm32/f4/stm32f429i-discovery/lcd-serial/lcd-spi.h
+++ b/examples/stm32/f4/stm32f429i-discovery/lcd-serial/lcd-spi.h
@@ -33,14 +33,14 @@ void lcd_draw_pixel(int x, int y, uint16_t color);
 
 /* Color definitions */
 #define	LCD_BLACK   0x0000
-#define	LCD_BLUE    0x1F00
-#define	LCD_RED     0x00F8
-#define	LCD_GREEN   0xE007
-#define LCD_CYAN    0xFF07
-#define LCD_MAGENTA 0x1FF8
-#define LCD_YELLOW  0xE0FF
+#define	LCD_BLUE    0x001F
+#define	LCD_RED     0xF800
+#define	LCD_GREEN   0x07E0
+#define LCD_CYAN    0x07FF
+#define LCD_MAGENTA 0xF81F
+#define LCD_YELLOW  0xFFE0
 #define LCD_WHITE   0xFFFF
-#define LCD_GREY    0xc339
+#define LCD_GREY    0x39c3
 
 /*
  * SPI Port and GPIO Defined - for STM32F4-Disco


### PR DESCRIPTION
This fixes the example to use real rgb565 colors by converting the byte-order to big-endian