### PR TITLE
fixes to match the libopencm3 adc changes

### DIFF
--- a/examples/stm32/f1/lisa-m-2/adc_injec/adc_injec.c
+++ b/examples/stm32/f1/lisa-m-2/adc_injec/adc_injec.c
@@ -67,7 +67,7 @@ static void adc_setup(void)
 	rcc_periph_clock_enable(RCC_ADC1);
 
 	/* Make sure the ADC doesn't run during config. */
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 
 	/* We configure everything for one single injected conversion. */
 	adc_disable_scan_mode(ADC1);

--- a/examples/stm32/f1/lisa-m-2/adc_injec_timtrig/adc_injec_timtrig.c
+++ b/examples/stm32/f1/lisa-m-2/adc_injec_timtrig/adc_injec_timtrig.c
@@ -87,7 +87,7 @@ static void adc_setup(void)
 	rcc_periph_clock_enable(RCC_ADC1);
 
 	/* Make sure the ADC doesn't run during config. */
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 
 	/* We configure everything for one single timer triggered injected conversion. */
 	adc_disable_scan_mode(ADC1);

--- a/examples/stm32/f1/lisa-m-2/adc_injec_timtrig_irq/adc_injec_timtrig_irq.c
+++ b/examples/stm32/f1/lisa-m-2/adc_injec_timtrig_irq/adc_injec_timtrig_irq.c
@@ -98,7 +98,7 @@ static void adc_setup(void)
 	rcc_periph_clock_enable(RCC_ADC1);
 
 	/* Make sure the ADC doesn't run during config. */
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 
 	/* We configure everything for one single timer triggered injected conversion with interrupt generation. */
 	/* While not needed for a single channel, try out scan mode which does all channels in one sweep and

--- a/examples/stm32/f1/lisa-m-2/adc_injec_timtrig_irq_4ch/adc_injec_timtrig_irq_4ch.c
+++ b/examples/stm32/f1/lisa-m-2/adc_injec_timtrig_irq_4ch/adc_injec_timtrig_irq_4ch.c
@@ -106,7 +106,7 @@ static void adc_setup(void)
 	rcc_periph_clock_enable(RCC_ADC1);
 
 	/* Make sure the ADC doesn't run during config. */
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 
 	/* We configure everything for one single timer triggered injected conversion with interrupt generation. */
 	/* While not needed for a single channel, try out scan mode which does all channels in one sweep and

--- a/examples/stm32/f1/lisa-m-2/adc_regular/adc.c
+++ b/examples/stm32/f1/lisa-m-2/adc_regular/adc.c
@@ -67,7 +67,7 @@ static void adc_setup(void)
 	rcc_periph_clock_enable(RCC_ADC1);
 
 	/* Make sure the ADC doesn't run during config. */
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 
 	/* We configure everything for one single conversion. */
 	adc_disable_scan_mode(ADC1);

--- a/examples/stm32/f1/other/adc_temperature_sensor/adc.c
+++ b/examples/stm32/f1/other/adc_temperature_sensor/adc.c
@@ -64,7 +64,7 @@ static void adc_setup(void)
 	rcc_periph_clock_enable(RCC_ADC1);
 
 	/* Make sure the ADC doesn't run during config. */
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 
 	/* We configure everything for one single conversion. */
 	adc_disable_scan_mode(ADC1);

--- a/examples/stm32/f1/stm32vl-discovery/adc-dac-printf/adc-dac-printf.c
+++ b/examples/stm32/f1/stm32vl-discovery/adc-dac-printf/adc-dac-printf.c
@@ -95,7 +95,7 @@ static void adc_setup(void)
 	gpio_set_mode(GPIOA, GPIO_MODE_INPUT, GPIO_CNF_INPUT_ANALOG, GPIO1);
 
 	/* Make sure the ADC doesn't run during config. */
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 
 	/* We configure everything for one single conversion. */
 	adc_disable_scan_mode(ADC1);

--- a/examples/stm32/f3/stm32f3-discovery/adc/adc.c
+++ b/examples/stm32/f3/stm32f3-discovery/adc/adc.c
@@ -52,19 +52,19 @@ static void adc_setup(void)
 	//ADC
 	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO0);
 	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO1);
-	adc_off(ADC1);
-	adc_set_clk_prescale(ADC_CCR_CKMODE_DIV2);
+	adc_power_off(ADC1);
+	adc_set_clk_prescale(ADC1,ADC_CCR_CKMODE_DIV2);
 	adc_set_single_conversion_mode(ADC1);
 	adc_disable_external_trigger_regular(ADC1);
 	adc_set_right_aligned(ADC1);
 	/* We want to read the temperature sensor, so we have to enable it. */
 	adc_enable_temperature_sensor();
-	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR1_SMP_61DOT5CYC);
+	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR_SMP_61DOT5CYC);
 	uint8_t channel_array[16];
 	channel_array[0]=16; // Vts (Internal temperature sensor
 	channel_array[0]=1; //ADC1_IN1 (PA0)
 	adc_set_regular_sequence(ADC1, 1, channel_array);
-	adc_set_resolution(ADC1, ADC_CFGR_RES_12_BIT);
+	adc_set_resolution(ADC1, ADC_CFGR1_RES_12_BIT);
 	adc_power_on(ADC1);
 
 	/* Wait for ADC starting up. */

--- a/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/adc-dac-printf.c
+++ b/examples/stm32/f4/stm32f4-discovery/adc-dac-printf/adc-dac-printf.c
@@ -98,7 +98,7 @@ static void adc_setup(void)
 	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO0);
 	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO1);
 
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 	adc_disable_scan_mode(ADC1);
 	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR_SMP_3CYC);
 

--- a/examples/stm32/f4/stm32f429i-discovery/adc-dac-printf/adc-dac-printf.c
+++ b/examples/stm32/f4/stm32f429i-discovery/adc-dac-printf/adc-dac-printf.c
@@ -99,7 +99,7 @@ static void adc_setup(void)
 	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO0);
 	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO1);
 
-	adc_off(ADC1);
+	adc_power_off(ADC1);
 	adc_disable_scan_mode(ADC1);
 	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR_SMP_3CYC);
 


### PR DESCRIPTION
The build of the examples fails after "git submodule update --remote"
these changes match the functions to the api changes.

However it does not fix the build, since adc-v2 lacks defines for the
ADC_CHANNELS. If those are added the full examples build works with
the current libopencm3

The corresponding issue is: https://github.com/libopencm3/libopencm3/issues/648