### PR TITLE
Makefile.rules: Allow lists for the BINARY variable.

### DIFF
--- a/examples/Makefile.rules
+++ b/examples/Makefile.rules
@@ -47,9 +47,9 @@ STYLECHECKFILES	:= $(shell find . -name '*.[ch]')
 ###############################################################################
 # Source files
 
-LDSCRIPT	?= $(BINARY).ld
+LDSCRIPT	?= $(addsuffix .ld,$(BINARY))
 
-OBJS		+= $(BINARY).o
+OBJS		+= $(addsuffix .o,$(BINARY))
 
 
 ifeq ($(strip $(OPENCM3_DIR)),)
@@ -125,14 +125,14 @@ LDLIBS		+= -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group
 
 all: elf
 
-elf: $(BINARY).elf
-bin: $(BINARY).bin
-hex: $(BINARY).hex
-srec: $(BINARY).srec
-list: $(BINARY).list
+elf: $(addsuffix .elf,$(BINARY))
+bin: $(addsuffix .bin,$(BINARY))
+hex: $(addsuffix .hex,$(BINARY))
+srec: $(addsuffix .srec,$(BINARY))
+list: $(addsuffix .list,$(BINARY))
 
-images: $(BINARY).images
-flash: $(BINARY).flash
+images: $(addsuffix .images,$(BINARY))
+flash: $(addsuffix .flash,$(BINARY))
 
 $(LDSCRIPT):
     ifeq (,$(wildcard $(LDSCRIPT)))

--- a/examples/stm32/f0/stm32f0-discovery/usart_stdio/Makefile
+++ b/examples/stm32/f0/stm32f0-discovery/usart_stdio/Makefile
@@ -17,7 +17,7 @@
 ## along with this library.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-BINARY = usart_stdio
+BINARY = 
 
 LDSCRIPT = ../stm32f0-discovery.ld
 

--- a/examples/stm32/f4/stm32f429i-discovery/lcd-dma/Makefile
+++ b/examples/stm32/f4/stm32f429i-discovery/lcd-dma/Makefile
@@ -1,6 +1,6 @@
 OBJS = sdram.o clock.o console.o lcd-spi.o
 
-BINARY = lcd-dma
+BINARY = 
 
 # we use sin/cos from the library
 LDLIBS += -lm


### PR DESCRIPTION
This allows building multiple binaries more easily. In this
case it is used to disable the build of targets that fail with
the 5.3 toolchain.
