### PR TITLE
cookie_io fixes for gcc-5.3

### DIFF
--- a/examples/stm32/f0/stm32f0-discovery/usart_stdio/usart_stdio.c
+++ b/examples/stm32/f0/stm32f0-discovery/usart_stdio/usart_stdio.c
@@ -18,6 +18,7 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define _GNU_SOURCE
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/usart.h>

--- a/examples/stm32/f4/stm32f429i-discovery/lcd-dma/console.c
+++ b/examples/stm32/f4/stm32f429i-discovery/lcd-dma/console.c
@@ -22,6 +22,7 @@
  *
  */
 
+#define _GNU_SOURCE
 #include <stdint.h>
 #include <stdio.h>
 #include <setjmp.h>


### PR DESCRIPTION
Using the latest (as of today) gcc-arm-embedded toolchain caused two build
failures similar to:

	error: unknown type name 'cookie_io_functions_t'

These custom IO functions are now protected by a define, so define _GNU_SOURCE
which enables all such areas. This is a libc issue.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>