### PR TITLE
[Makefile]: add objects to clean target

### DIFF
--- a/examples/Makefile.rules
+++ b/examples/Makefile.rules
@@ -176,7 +176,7 @@ $(LDSCRIPT):
 
 clean:
 	@#printf "  CLEAN\n"
-	$(Q)$(RM) *.o *.d *.elf *.bin *.hex *.srec *.list *.map
+	$(Q)$(RM) *.o *.d *.elf *.bin *.hex *.srec *.list *.map ${OBJS} ${OBJS:%.o:%.d}
 
 stylecheck: $(STYLECHECKFILES:=.stylecheck)
 styleclean: $(STYLECHECKFILES:=.styleclean)


### PR DESCRIPTION
Some demos will use object files from a different directory and
those files would not be cleaned by the simple CLEAN rule. This
small change insures that those objects and their dependency files
are also cleaned.