### PR TITLE
stm32 button: use more idiomatic GPIO read

### DIFF
--- a/examples/stm32/f1/stm32-h103/button/button.c
+++ b/examples/stm32/f1/stm32-h103/button/button.c
@@ -23,8 +23,6 @@
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/exti.h>
 
-uint16_t exti_line_state;
-
 /* Set STM32 to 72 MHz. */
 static void clock_setup(void)
 {
@@ -62,8 +60,7 @@ int main(void)
 	while (1) {
 		gpio_toggle(GPIOC, GPIO12);
 
-		exti_line_state = GPIOA_IDR;
-		if ((exti_line_state & (1 << 0)) != 0) {
+		if (gpio_get(GPIOA, GPIO0)) {
 			for (i = 0; i < 800000; i++)	/* Wait a bit. */
 				__asm__("nop");
 		}

--- a/examples/stm32/f1/stm32vl-discovery/button/button.c
+++ b/examples/stm32/f1/stm32vl-discovery/button/button.c
@@ -21,8 +21,6 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 
-uint16_t exti_line_state;
-
 /* Set STM32 to 24 MHz. */
 static void clock_setup(void)
 {
@@ -61,8 +59,7 @@ int main(void)
 		gpio_toggle(GPIOC, GPIO9);
 
 		/* Upon button press, blink more slowly. */
-		exti_line_state = GPIOA_IDR;
-		if ((exti_line_state & (1 << 0)) != 0) {
+		if (gpio_get(GPIOA, GPIO0)) {
 			for (i = 0; i < 800000; i++)	/* Wait a bit. */
 				__asm__("nop");
 		}

--- a/examples/stm32/f1/waveshare-open103r/button/button.c
+++ b/examples/stm32/f1/waveshare-open103r/button/button.c
@@ -22,8 +22,6 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 
-uint16_t exti_line_state;
-
 /* Set STM32 to 24 MHz. */
 static void clock_setup(void)
 {
@@ -64,8 +62,7 @@ int main(void)
 		gpio_toggle(GPIOC, GPIO9);
 
 		/* Upon button press, blink more slowly. */
-		exti_line_state = GPIOA_IDR;
-		if ((exti_line_state & (1 << 9)) == 0) {
+		if (gpio_get(GPIOA, GPIO9)) {
 			for (i = 0; i < 800000; i++)	/* Wait a bit. */
 				__asm__("nop");
 		}

--- a/examples/stm32/f3/stm32f3-discovery/button/button.c
+++ b/examples/stm32/f3/stm32f3-discovery/button/button.c
@@ -24,8 +24,6 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 
-uint16_t exti_line_state;
-
 /* Set STM32 to 64 MHz. */
 static void clock_setup(void)
 {
@@ -64,8 +62,7 @@ int main(void)
 		gpio_toggle(GPIOE, GPIO11);
 
 		/* Upon button press, blink more slowly. */
-		exti_line_state = GPIOA_IDR;
-		if ((exti_line_state & (1 << 0)) != 0) {
+		if (gpio_get(GPIOA, GPIO0)) {
 			for (i = 0; i < 3000000; i++)	/* Wait a bit. */
 				__asm__("nop");
 		}

--- a/examples/stm32/f4/stm32f4-discovery/button/button.c
+++ b/examples/stm32/f4/stm32f4-discovery/button/button.c
@@ -22,8 +22,6 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 
-uint16_t exti_line_state;
-
 /* Set STM32 to 168 MHz. */
 static void clock_setup(void)
 {
@@ -62,8 +60,7 @@ int main(void)
 		gpio_toggle(GPIOD, GPIO12);
 
 		/* Upon button press, blink more slowly. */
-		exti_line_state = GPIOA_IDR;
-		if ((exti_line_state & (1 << 0)) != 0) {
+		if (gpio_get(GPIOA, GPIO0)) {
 			for (i = 0; i < 3000000; i++) {	/* Wait a bit. */
 				__asm__("nop");
 			}

--- a/examples/stm32/f4/stm32f429i-discovery/button/button.c
+++ b/examples/stm32/f4/stm32f429i-discovery/button/button.c
@@ -22,8 +22,6 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 
-uint16_t exti_line_state;
-
 /* Set STM32 to 168 MHz. */
 static void clock_setup(void)
 {
@@ -62,8 +60,7 @@ int main(void)
 		gpio_toggle(GPIOG, GPIO13);
 
 		/* Upon button press, blink more slowly. */
-		exti_line_state = GPIOA_IDR;
-		if ((exti_line_state & (1 << 0)) != 0) {
+		if (gpio_get(GPIOA, GPIO0)) {
 			for (i = 0; i < 3000000; i++) {	/* Wait a bit. */
 				__asm__("nop");
 			}


### PR DESCRIPTION
Using GPIOA_IDR directly looks a bit arcane, and the example can benefit from introducing gpio_get() and how to use it.