### PR TITLE
timer_reset -> rcc_periph_reset_pulse() replace

### DIFF
--- a/examples/stm32/f1/lisa-m-2/adc_injec_timtrig/adc_injec_timtrig.c
+++ b/examples/stm32/f1/lisa-m-2/adc_injec_timtrig/adc_injec_timtrig.c
@@ -70,7 +70,7 @@ static void timer_setup(void)
 	rcc_periph_clock_enable(RCC_TIM2);
 
 	/* Time Base configuration */
-    timer_reset(timer);
+    rcc_periph_reset_pulse(RST_TIM2);
     timer_set_mode(timer, TIM_CR1_CKD_CK_INT,
 	    TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
     timer_set_period(timer, 0xFF);

--- a/examples/stm32/f1/lisa-m-2/adc_injec_timtrig_irq/adc_injec_timtrig_irq.c
+++ b/examples/stm32/f1/lisa-m-2/adc_injec_timtrig_irq/adc_injec_timtrig_irq.c
@@ -73,7 +73,7 @@ static void timer_setup(void)
 	rcc_periph_clock_enable(RCC_TIM2);
 
 	/* Time Base configuration */
-    timer_reset(timer);
+    rcc_periph_reset_pulse(RST_TIM2);
     timer_set_mode(timer, TIM_CR1_CKD_CK_INT,
 	    TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
     timer_set_period(timer, 0xFF);

--- a/examples/stm32/f1/lisa-m-2/adc_injec_timtrig_irq_4ch/adc_injec_timtrig_irq_4ch.c
+++ b/examples/stm32/f1/lisa-m-2/adc_injec_timtrig_irq_4ch/adc_injec_timtrig_irq_4ch.c
@@ -81,7 +81,7 @@ static void timer_setup(void)
 	rcc_periph_clock_enable(RCC_TIM2);
 
 	/* Time Base configuration */
-    timer_reset(timer);
+    rcc_periph_reset_pulse(RST_TIM2);
     timer_set_mode(timer, TIM_CR1_CKD_CK_INT,
 	    TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
     timer_set_period(timer, 0xFF);

--- a/examples/stm32/f1/stm32-h103/pwm_6step/pwm_6step.c
+++ b/examples/stm32/f1/stm32-h103/pwm_6step/pwm_6step.c
@@ -110,7 +110,7 @@ static void tim_setup(void)
 	nvic_enable_irq(NVIC_TIM1_TRG_COM_IRQ);
 
 	/* Reset TIM1 peripheral. */
-	timer_reset(TIM1);
+	rcc_periph_reset_pulse(RST_TIM1);
 
 	/* Timer global mode:
 	 * - No divider

--- a/examples/stm32/f1/stm32-h103/timer/timer.c
+++ b/examples/stm32/f1/stm32-h103/timer/timer.c
@@ -77,7 +77,7 @@ static void tim_setup(void)
 	nvic_enable_irq(NVIC_TIM2_IRQ);
 
 	/* Reset TIM2 peripheral. */
-	timer_reset(TIM2);
+	rcc_periph_reset_pulse(RST_TIM2);
 
 	/* Timer global mode:
 	 * - No divider

--- a/examples/stm32/f4/stm32f4-discovery/dac-dma/dac-dma.c
+++ b/examples/stm32/f4/stm32f4-discovery/dac-dma/dac-dma.c
@@ -54,7 +54,7 @@ static void timer_setup(void)
 {
 	/* Enable TIM2 clock. */
 	rcc_periph_clock_enable(RCC_TIM2);
-	timer_reset(TIM2);
+	rcc_periph_reset_pulse(RST_TIM2);
 	/* Timer global mode: - No divider, Alignment edge, Direction up */
 	timer_set_mode(TIM2, TIM_CR1_CKD_CK_INT,
 		       TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);

--- a/examples/stm32/f4/stm32f4-discovery/timer/timer.c
+++ b/examples/stm32/f4/stm32f4-discovery/timer/timer.c
@@ -81,7 +81,7 @@ static void tim_setup(void)
 	nvic_enable_irq(NVIC_TIM2_IRQ);
 
 	/* Reset TIM2 peripheral. */
-	timer_reset(TIM2);
+	rcc_periph_reset_pulse(RST_TIM2);
 
 	/* Timer global mode:
 	 * - No divider

--- a/examples/stm32/f4/stm32f429i-discovery/dac-dma/dac-dma.c
+++ b/examples/stm32/f4/stm32f429i-discovery/dac-dma/dac-dma.c
@@ -55,7 +55,7 @@ static void timer_setup(void)
 {
 	/* Enable TIM2 clock. */
 	rcc_periph_clock_enable(RCC_TIM2);
-	timer_reset(TIM2);
+	rcc_periph_reset_pulse(RST_TIM2);
 	/* Timer global mode: - No divider, Alignment edge, Direction up */
 	timer_set_mode(TIM2, TIM_CR1_CKD_CK_INT,
 		       TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);

--- a/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/main.c
+++ b/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/main.c
@@ -131,7 +131,7 @@ int _write(int file, char *ptr, int len)
  */
 static void setup_button_press_timer(void)
 {
-	timer_reset(TIMER_BUTTON_PRESS);
+	rcc_periph_reset_pulse(TIMER_BUTTON_PRESS_RST);
 	timer_set_prescaler(TIMER_BUTTON_PRESS, 3999); /* 4Mhz/1000hz - 1 */
 	timer_set_period(TIMER_BUTTON_PRESS, 0xffff);
 	timer_enable_counter(TIMER_BUTTON_PRESS);

--- a/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/syscfg.h
+++ b/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/syscfg.h
@@ -44,6 +44,7 @@ extern "C" {
 #define BUTTON_DISCO_USER_isr exti0_isr
 #define BUTTON_DISCO_USER_NVIC NVIC_EXTI0_IRQ
 #define TIMER_BUTTON_PRESS TIM7
+#define TIMER_BUTTON_PRESS_RST RST_TIM7
 
 	struct state_t {
 		bool falling;

--- a/examples/stm32/l1/stm32l-discovery/button-irq-printf/main.c
+++ b/examples/stm32/l1/stm32l-discovery/button-irq-printf/main.c
@@ -137,7 +137,7 @@ void tim6_isr(void)
  */
 static void setup_tim6(void)
 {
-	timer_reset(TIM6);
+	rcc_periph_reset_pulse(RST_TIM6);
 	/* 24Mhz / 10khz -1. */
 	timer_set_prescaler(TIM6, 2399); /* 24Mhz/10000hz - 1 */
 	/* 10khz for 10 ticks = 1 khz overflow = 1ms overflow interrupts */
@@ -154,7 +154,7 @@ static void setup_tim6(void)
  */
 static void setup_tim7(void)
 {
-	timer_reset(TIM7);
+	rcc_periph_reset_pulse(RST_TIM7);
 	timer_set_prescaler(TIM7, 23999); /* 24Mhz/1000hz - 1 */
 	timer_set_period(TIM7, 0xffff);
 	timer_enable_counter(TIM7);


### PR DESCRIPTION
timer_reset wasn't fully implemented for all timers on all series, and
was simply a wrapper of the RST bits in the RCC registers anyway.

First part of https://github.com/libopencm3/libopencm3/issues/709