### PR TITLE
Better Debugging in make

### DIFF
--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -164,6 +164,13 @@ else
 include $(OPENCM3_DIR)/mk/genlink-rules.mk
 endif
 
+# Define a helper macro for debugging make errors online
+# you can type "make print-OPENCM3_DIR" and it will show you
+# how that ended up being resolved by all of the included
+# makefiles.
+print-%:
+	@echo $*=$($*)
+
 %.images: %.bin %.hex %.srec %.list %.map
 	@#printf "*** $* images generated ***\n"
 
@@ -221,14 +228,14 @@ styleclean: $(STYLECHECKFILES:=.styleclean)
 
 %.stlink-flash: %.bin
 	@printf "  FLASH  $<\n"
-	$(Q)$(STFLASH) write $(*).bin 0x8000000
+	$(STFLASH) write $(*).bin 0x8000000
 
 ifeq ($(STLINK_PORT),)
 ifeq ($(BMP_PORT),)
 ifeq ($(OOCD_FILE),)
 %.flash: %.elf
 	@printf "  FLASH   $<\n"
-	$(Q)(echo "halt; program $(realpath $(*).elf) verify reset" | nc -4 localhost 4444 2>/dev/null) || \
+	(echo "halt; program $(realpath $(*).elf) verify reset" | nc -4 localhost 4444 2>/dev/null) || \
 		$(OOCD) -f interface/$(OOCD_INTERFACE).cfg \
 		-f target/$(OOCD_TARGET).cfg \
 		-c "program $(*).elf verify reset exit" \
@@ -236,7 +243,7 @@ ifeq ($(OOCD_FILE),)
 else
 %.flash: %.elf
 	@printf "  FLASH   $<\n"
-	$(Q)(echo "halt; program $(realpath $(*).elf) verify reset" | nc -4 localhost 4444 2>/dev/null) || \
+	(echo "halt; program $(realpath $(*).elf) verify reset" | nc -4 localhost 4444 2>/dev/null) || \
 		$(OOCD) -f $(OOCD_FILE) \
 		-c "program $(*).elf verify reset exit" \
 		$(NULL)
@@ -244,7 +251,7 @@ endif
 else
 %.flash: %.elf
 	@printf "  GDB   $(*).elf (flash)\n"
-	$(Q)$(GDB) --batch \
+	$(GDB) --batch \
 		   -ex 'target extended-remote $(BMP_PORT)' \
 		   -x $(SCRIPT_DIR)/black_magic_probe_flash.scr \
 		   $(*).elf
@@ -252,7 +259,7 @@ endif
 else
 %.flash: %.elf
 	@printf "  GDB   $(*).elf (flash)\n"
-	$(Q)$(GDB) --batch \
+	$(GDB) --batch \
 		   -ex 'target extended-remote $(STLINK_PORT)' \
 		   -x $(SCRIPT_DIR)/stlink_flash.scr \
 		   $(*).elf


### PR DESCRIPTION
This commit does two things, it removes the "Quiet" flag
from the flash target so you can see what it is trying to
do when it trys to flash your code, and it adds a make
target print-% which can be used to print the resolved
value of make variables (also helpful in figuring out
what it is trying to do).