### PR TITLE
Fixed wrong script dir location for flash targets

### DIFF
--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -231,7 +231,6 @@ styleclean: $(STYLECHECKFILES:=.styleclean)
 	@printf "  FLASH  $<\n"
 	$(STFLASH) write $(*).bin 0x8000000
 
-ifeq ($(STLINK_PORT),)
 ifeq ($(BMP_PORT),)
 ifeq ($(OOCD_FILE),)
 %.flash: %.elf
@@ -255,14 +254,6 @@ else
 	$(GDB) --batch \
 		   -ex 'target extended-remote $(BMP_PORT)' \
 		   -x $(EXAMPLES_SCRIPT_DIR)/black_magic_probe_flash.scr \
-		   $(*).elf
-endif
-else
-%.flash: %.elf
-	@printf "  GDB   $(*).elf (flash)\n"
-	$(GDB) --batch \
-		   -ex 'target extended-remote $(STLINK_PORT)' \
-		   -x $(EXAMPLES_SCRIPT_DIR)/stlink_flash.scr \
 		   $(*).elf
 endif
 

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -93,7 +93,7 @@ include $(OPENCM3_DIR)/mk/genlink-config.mk
 endif
 
 OPENCM3_SCRIPT_DIR = $(OPENCM3_DIR)/scripts
-EXAMPLES_SCRIPT_DIR	= $(OPENCM3_DIR)../scripts
+EXAMPLES_SCRIPT_DIR	= $(OPENCM3_DIR)/../scripts
 
 ###############################################################################
 # C flags

--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -92,7 +92,8 @@ endif
 include $(OPENCM3_DIR)/mk/genlink-config.mk
 endif
 
-SCRIPT_DIR	= $(OPENCM3_DIR)/scripts
+OPENCM3_SCRIPT_DIR = $(OPENCM3_DIR)/scripts
+EXAMPLES_SCRIPT_DIR	= $(OPENCM3_DIR)../scripts
 
 ###############################################################################
 # C flags
@@ -215,7 +216,7 @@ styleclean: $(STYLECHECKFILES:=.styleclean)
 
 # the cat is due to multithreaded nature - we like to have consistent chunks of text on the output
 %.stylecheck: %
-	$(Q)$(SCRIPT_DIR)$(STYLECHECK) $(STYLECHECKFLAGS) $* > $*.stylecheck; \
+	$(Q)$(OPENCM3_SCRIPT_DIR)$(STYLECHECK) $(STYLECHECKFLAGS) $* > $*.stylecheck; \
 		if [ -s $*.stylecheck ]; then \
 			cat $*.stylecheck; \
 		else \
@@ -253,7 +254,7 @@ else
 	@printf "  GDB   $(*).elf (flash)\n"
 	$(GDB) --batch \
 		   -ex 'target extended-remote $(BMP_PORT)' \
-		   -x $(SCRIPT_DIR)/black_magic_probe_flash.scr \
+		   -x $(EXAMPLES_SCRIPT_DIR)/black_magic_probe_flash.scr \
 		   $(*).elf
 endif
 else
@@ -261,7 +262,7 @@ else
 	@printf "  GDB   $(*).elf (flash)\n"
 	$(GDB) --batch \
 		   -ex 'target extended-remote $(STLINK_PORT)' \
-		   -x $(SCRIPT_DIR)/stlink_flash.scr \
+		   -x $(EXAMPLES_SCRIPT_DIR)/stlink_flash.scr \
 		   $(*).elf
 endif
 


### PR DESCRIPTION
This PR tries to fix some of #34 
It seems like there are 2 script dirs, one in the examples and one in the library itself. The scripts for the BMP are in the examples/scripts dir, not the library one.

I can't seem to find the `stlink_flash.scr` script anywhere though :/