### PR TITLE
Adding some examples for a barebones stm32f030f4 on a breakout board

### DIFF
--- a/examples/stm32/f0/stm32f0-breakout/i2c-dac/Makefile
+++ b/examples/stm32/f0/stm32f0-breakout/i2c-dac/Makefile
@@ -1,0 +1,24 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2018 Roel Jordans <r.jordans@tue.nl>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY          = i2c-dac
+LDSCRIPT        = ../stm32f0-breakout.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f0/stm32f0-breakout/i2c-dac/README.md
+++ b/examples/stm32/f0/stm32f0-breakout/i2c-dac/README.md
@@ -1,0 +1,17 @@
+# README
+
+Getting started with I2C project for a bare-bones stm32f030 board with 20-pin TSOP package.  Driving an MCP4725 DAC over I2C.
+
+## Board connections
+
+| Pin | Port          | Function              | Description                   |
+| --- | ------------- | --------------------- | ----------------------------- |
+|  1  | `(BOOT0)`     | Boot mode selection   | Pull low                      |
+|  4  | `(NRST)`      | Reset                 | Pull high                     |
+|  5  | `(VDDA)`      | Analog power          | Connect to V+                 |
+| 15  | `(VSS)`       | Ground pin            | Connect to ground             |
+| 16  | `(VDD)`       | Logic power           | Connect to V+                 |
+| 17  | `(SCL)`       | I2C clock             | Connect to DAC SCL            |
+| 18  | `(SDA)`       | I2C data              | Connect to DAC SDA            |
+| 19  | `(SYS_SWDIO)` | Programming interface | Connect to ST-Link programmer |
+| 20  | `(SYS_SWCLK)` | Programming interface | Connect to ST-Link programmer |

--- a/examples/stm32/f0/stm32f0-breakout/i2c-dac/i2c-dac.c
+++ b/examples/stm32/f0/stm32f0-breakout/i2c-dac/i2c-dac.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2018 Roel Jordans <r.jordans@tue.nl>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/i2c.h>
+
+/* Wait a bit */
+static void delay(int n)
+{
+	for (int i = 0; i < n; i++) {
+		__asm__("nop");
+	}
+}
+
+/* Setup I2C1 interface */
+static void i2c_setup(void)
+{
+	/* Enable GPIOA and I2C1 clocks. */
+	rcc_periph_clock_enable(RCC_GPIOA);
+	rcc_periph_clock_enable(RCC_I2C1);
+	i2c_reset(I2C1);
+
+	/* Set I2C mode with external pullups */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO9 | GPIO10);
+	gpio_set_af(GPIOA, GPIO_AF4, GPIO9 | GPIO10);
+	i2c_peripheral_disable(I2C1);
+
+	/* Configure ANFOFF DNF[3:0] in CR1 */
+	i2c_enable_analog_filter(I2C1);
+	i2c_set_digital_filter(I2C1, 0);
+
+	/* Configure I2C bus speed, uses 8MHz HSI clock internally */
+	i2c_set_speed(I2C1, i2c_speed_sm_100k, 8);
+
+	/* Configure No-Stretch CR1 (only relevant in slave mode) */
+	i2c_enable_stretching(I2C1);
+
+	/* Addressing mode */
+	i2c_set_7bit_addr_mode(I2C1);
+	i2c_peripheral_enable(I2C1);
+}
+
+/* Set DAC output register value */
+static void mcp4725_set_value(uint32_t i2c, uint8_t addr, uint32_t val)
+{
+	/* Command package, 2 bytes with last 12 bits the value, high bits 0 */
+	uint8_t command[] = { (val >> 8) & 0x0f, val & 0xff};
+
+	/* I2C transfer data */
+	i2c_transfer7(i2c, addr, command, sizeof(command), NULL, 0);
+}
+
+int main(void)
+{
+	rcc_clock_setup_in_hsi_out_48mhz();
+
+	i2c_setup();
+
+	/* Write sawtooth shape to DAC output */
+	int val = 0;
+	while (1) {
+		/* Set value */
+		mcp4725_set_value(I2C1, 0x62, val++);
+
+		/* Wrap-around to keep within 12 bit resolution */
+		val &= 0xfff;
+
+		/* Wait a bit */
+		delay(4000);
+	}
+
+	return 0;
+}

--- a/examples/stm32/f0/stm32f0-breakout/miniblink/Makefile
+++ b/examples/stm32/f0/stm32f0-breakout/miniblink/Makefile
@@ -1,0 +1,24 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2018 Roel Jordans <r.jordans@tue.nl>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY          = miniblink
+LDSCRIPT        = ../stm32f0-breakout.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f0/stm32f0-breakout/miniblink/README.md
+++ b/examples/stm32/f0/stm32f0-breakout/miniblink/README.md
@@ -1,0 +1,16 @@
+# README
+
+Minimal getting started project for a bare-bones stm32f030 board with 20-pin TSOP package.
+
+## Board connections
+
+| Pin | Port          | Function              | Description                   |
+| --- | ------------- | --------------------- | ----------------------------- |
+|  1  | `(BOOT0)`     | Boot mode selection   | Pull low                      |
+|  4  | `(NRST)`      | Reset                 | Pull high                     |
+|  5  | `(VDDA)`      | Analog power          | Connect to V+                 |
+| 11  | `(PA5)`       | GPIO                  | Drives LED output             |
+| 15  | `(VSS)`       | Ground pin            | Connect to ground             |
+| 16  | `(VDD)`       | Logic power           | Connect to V+                 |
+| 19  | `(SYS_SWDIO)` | Programming interface | Connect to ST-Link programmer |
+| 20  | `(SYS_SWCLK)` | Programming interface | Connect to ST-Link programmer |

--- a/examples/stm32/f0/stm32f0-breakout/miniblink/miniblink.c
+++ b/examples/stm32/f0/stm32f0-breakout/miniblink/miniblink.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2018 Roel Jordans <r.jordans@tue.nl>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/flash.h>
+
+#define PORT_LED GPIOA
+#define PIN_LED GPIO5
+
+static void delay(int n)
+{
+	for (int i = 0; i < n; i++) {	/* Wait a bit. */
+		__asm__("nop");
+	}
+}
+
+static void gpio_setup(void)
+{
+	/* Enable GPIOA clock. */
+	rcc_periph_clock_enable(RCC_GPIOA);
+
+	/* Set GPIO5 (in GPIO port A) to 'output push-pull'. */
+	gpio_mode_setup(PORT_LED, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, PIN_LED);
+}
+
+int main(void)
+{
+	rcc_clock_setup_in_hsi_out_48mhz();
+
+	gpio_setup();
+
+	/* Blink the LED (PA5) on the board. */
+	while (1) {
+		gpio_toggle(PORT_LED, PIN_LED);	/* LED on/off */
+		delay(4000000);
+	}
+
+	return 0;
+}

--- a/examples/stm32/f0/stm32f0-breakout/stm32f0-breakout.ld
+++ b/examples/stm32/f0/stm32f0-breakout/stm32f0-breakout.ld
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (C) 2018 Roel Jordans <r.jordans@tue.nl>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for ST STM32F030 breakout (STM32F030F4, 16 flash, 4K RAM). */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 16K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 4K
+}
+
+/* Include the common ld script. */
+INCLUDE libopencm3_stm32f0.ld
+


### PR DESCRIPTION
Based on snippets I was using while developing libopencm3 code on a stm32f030 chip in a breadboard setup and playing around with the library.  Each project comes with a readme with brief wiring instructions.

I have some more in progress (usart / timer / exti) if there is interest in this kind of barebone setup.