### PR TITLE
INCOMPLETE: use generic linker scripts

### DIFF
--- a/examples/lpc/lpc13xx/lpc-p1343/lpc-p1343.ld
+++ b/examples/lpc/lpc13xx/lpc-p1343/lpc-p1343.ld
@@ -27,4 +27,4 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_lpc13xx.ld
+INCLUDE cortex-m-generic.ld

--- a/examples/lpc/lpc17xx/blueboard-lpc1768-h/blueboard-lpc1768-h.ld
+++ b/examples/lpc/lpc17xx/blueboard-lpc1768-h/blueboard-lpc1768-h.ld
@@ -29,4 +29,4 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_lpc17xx.ld
+INCLUDE cortex-m-generic.ld

--- a/examples/stm32/f0/stm32f0-discovery/stm32f0-discovery.ld
+++ b/examples/stm32/f0/stm32f0-discovery/stm32f0-discovery.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f0.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/lisa-m-1/lisa-m.ld
+++ b/examples/stm32/f1/lisa-m-1/lisa-m.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/lisa-m-2/lisa-m.ld
+++ b/examples/stm32/f1/lisa-m-2/lisa-m.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/mb525/mb525.ld
+++ b/examples/stm32/f1/mb525/mb525.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/obldc-strip/obldc-strip.ld
+++ b/examples/stm32/f1/obldc-strip/obldc-strip.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/obldc/obldc.ld
+++ b/examples/stm32/f1/obldc/obldc.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/other/adc_temperature_sensor/adc.ld
+++ b/examples/stm32/f1/other/adc_temperature_sensor/adc.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/other/dma_mem2mem/dma.ld
+++ b/examples/stm32/f1/other/dma_mem2mem/dma.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/other/dogm128/main.ld
+++ b/examples/stm32/f1/other/dogm128/main.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/other/i2c_stts75_sensor/i2c_stts75_sensor.ld
+++ b/examples/stm32/f1/other/i2c_stts75_sensor/i2c_stts75_sensor.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/other/systick/systick.ld
+++ b/examples/stm32/f1/other/systick/systick.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/other/timer_interrupt/timer.ld
+++ b/examples/stm32/f1/other/timer_interrupt/timer.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/other/usb_cdcacm/cdcacm.ld
+++ b/examples/stm32/f1/other/usb_cdcacm/cdcacm.ld
@@ -25,5 +25,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/other/usb_dfu/usbdfu.ld
+++ b/examples/stm32/f1/other/usb_dfu/usbdfu.ld
@@ -25,5 +25,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/other/usb_hid/usbhid.ld
+++ b/examples/stm32/f1/other/usb_hid/usbhid.ld
@@ -25,5 +25,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/stm32-h103/stm32-h103.ld
+++ b/examples/stm32/f1/stm32-h103/stm32-h103.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/stm32-h107/stm32-h107.ld
+++ b/examples/stm32/f1/stm32-h107/stm32-h107.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/stm32-maple/stm32-maple.ld
+++ b/examples/stm32/f1/stm32-maple/stm32-maple.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/stm32vl-discovery/stm32vl-discovery.ld
+++ b/examples/stm32/f1/stm32vl-discovery/stm32vl-discovery.ld
@@ -27,5 +27,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f1/waveshare-open103r/waveshare-open103r.ld
+++ b/examples/stm32/f1/waveshare-open103r/waveshare-open103r.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f2/jobygps/jobygps.ld
+++ b/examples/stm32/f2/jobygps/jobygps.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f2.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f3/stm32f3-discovery/stm32f3-discovery.ld
+++ b/examples/stm32/f3/stm32f3-discovery/stm32f3-discovery.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f3.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f4/nucleo-f411re/nucleo-f411re.ld
+++ b/examples/stm32/f4/nucleo-f411re/nucleo-f411re.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f4.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f4/other/stm32f4-discovery.ld
+++ b/examples/stm32/f4/other/stm32f4-discovery.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f4.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f4/stm32f4-discovery/stm32f4-discovery.ld
+++ b/examples/stm32/f4/stm32f4-discovery/stm32f4-discovery.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f4.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/stm32/f4/stm32f429i-discovery/stm32f429i-discovery.ld
+++ b/examples/stm32/f4/stm32f429i-discovery/stm32f429i-discovery.ld
@@ -29,5 +29,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f4.ld
+INCLUDE cortex-m-generic.ld
 

--- a/examples/tiva/lm3s/lm3s3748-evb/lm3s3748-evb.ld
+++ b/examples/tiva/lm3s/lm3s3748-evb/lm3s3748-evb.ld
@@ -27,4 +27,4 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_lm3s.ld
+INCLUDE cortex-m-generic.ld

--- a/examples/tiva/lm3s/lm3s811-evb/lm3s811-evb.ld
+++ b/examples/tiva/lm3s/lm3s811-evb/lm3s811-evb.ld
@@ -27,4 +27,4 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_lm3s.ld
+INCLUDE cortex-m-generic.ld

--- a/examples/tiva/lm4f/stellaris-ek-lm4f120xl/ek-lm4f120xl.ld
+++ b/examples/tiva/lm4f/stellaris-ek-lm4f120xl/ek-lm4f120xl.ld
@@ -27,4 +27,4 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_lm4f.ld
+INCLUDE cortex-m-generic.ld


### PR DESCRIPTION
Now that the library provides a generic linker script for cortex-m, use
that instead of the redundant per target linker script stubs that were
used before.

INCOMPLETE: doesn't include the library update, see https://github.com/libopencm3/libopencm3/pull/892 but here to present the changes required.