### PR TITLE
fix memory map for stm32f429

### DIFF
--- a/examples/stm32/f4/stm32f429i-discovery/stm32f429i-discovery.ld
+++ b/examples/stm32/f4/stm32f429i-discovery/stm32f429i-discovery.ld
@@ -25,7 +25,8 @@
 MEMORY
 {
 	rom (rx) : ORIGIN = 0x08000000, LENGTH = 2048K
-	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K /* (esden) This should be 256 but I get segfault. :( */
+ 	ccm (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 192K
 }
 
 /* Include the common ld script. */


### PR DESCRIPTION
The assumed memory map for the STM32F429 is wrong.
The RAM is segmented into a main part at 0x20000000 of 192k size and a CCM (core coupled memory) area at 0x10000000 of 64k size.

So it is correct that the STM32F429 has 256k RAM in total, but it is segmented as described above. That is the reason why you can a Hard Fault soon after reset if you try to set the ram length to 256k. 

For memory map detail take a look at the [data sheet of the STM32F429](http://www.st.com/content/ccc/resource/technical/document/datasheet/03/b4/b2/36/4c/72/49/29/DM00071990.pdf/files/DM00071990.pdf/jcr:content/translations/en.DM00071990.pdf).