### PR TITLE
stm32f3/i2c: clean up code

### DIFF
--- a/examples/stm32/f3/stm32f3-discovery/i2c/i2c.c
+++ b/examples/stm32/f3/stm32f3-discovery/i2c/i2c.c
@@ -116,17 +116,18 @@ static void clock_setup(void)
 
 int main(void)
 {
+	uint8_t cmd = ACC_CTRL_REG1_A;
+	uint8_t data;
+	int16_t acc_x;
+
 	clock_setup();
 	gpio_setup();
 	usart_setup();
 	printf("Hello, we're running\n");
 	i2c_setup();
-	uint8_t cmd = ACC_CTRL_REG1_A;
-	uint8_t data;
 	i2c_transfer7(I2C1, I2C_ACC_ADDR, &cmd, 1, &data, 1);
 	cmd = ACC_CTRL_REG4_A;
 	i2c_transfer7(I2C1, I2C_ACC_ADDR, &cmd, 1, &data, 1);
-	int16_t acc_x;
 
 	while (1) {
 

--- a/examples/stm32/f3/stm32f3-discovery/i2c/i2c.c
+++ b/examples/stm32/f3/stm32f3-discovery/i2c/i2c.c
@@ -27,23 +27,6 @@
 #include <libopencm3/stm32/i2c.h>
 #include <libopencm3/stm32/gpio.h>
 
-#define LBLUE GPIOE, GPIO8
-#define LRED GPIOE, GPIO9
-#define LORANGE GPIOE, GPIO10
-#define LGREEN GPIOE, GPIO11
-#define LBLUE2 GPIOE, GPIO12
-#define LRED2 GPIOE, GPIO13
-#define LORANGE2 GPIOE, GPIO14
-#define LGREEN2 GPIOE, GPIO15
-
-#define LD4 GPIOE, GPIO8
-#define LD3 GPIOE, GPIO9
-#define LD5 GPIOE, GPIO10
-#define LD7 GPIOE, GPIO11
-#define LD9 GPIOE, GPIO12
-#define LD10 GPIOE, GPIO13
-#define LD8 GPIOE, GPIO14
-#define LD6 GPIOE, GPIO15
 
 int _write(int file, char *ptr, int len);
 
@@ -124,12 +107,8 @@ static void clock_setup(void)
 }
 
 #define I2C_ACC_ADDR 0x19
-#define I2C_MAG_ADDR 0x1E
 #define ACC_STATUS 0x27
 #define ACC_CTRL_REG1_A 0x20
-#define ACC_CTRL_REG1_A_ODR_SHIFT 4
-#define ACC_CTRL_REG1_A_ODR_MASK 0xF
-#define ACC_CTRL_REG1_A_XEN (1 << 0)
 #define ACC_CTRL_REG4_A 0x23
 
 #define ACC_OUT_X_L_A 0x28

--- a/examples/stm32/f3/stm32f3-discovery/i2c/i2c.c
+++ b/examples/stm32/f3/stm32f3-discovery/i2c/i2c.c
@@ -28,14 +28,6 @@
 #include <libopencm3/stm32/gpio.h>
 
 
-int _write(int file, char *ptr, int len);
-
-static void i2c_setup(void);
-static void usart_setup(void);
-static void gpio_setup(void);
-static void clock_setup(void);
-
-
 #define I2C_ACC_ADDR 0x19
 #define ACC_STATUS 0x27
 #define ACC_CTRL_REG1_A 0x20
@@ -43,6 +35,15 @@ static void clock_setup(void);
 
 #define ACC_OUT_X_L_A 0x28
 #define ACC_OUT_X_H_A 0x29
+
+
+int _write(int file, char *ptr, int len);
+
+static void i2c_setup(void);
+static void usart_setup(void);
+static void gpio_setup(void);
+static void clock_setup(void);
+
 
 int main(void)
 {


### PR DESCRIPTION
 - Removed unused macros:
	LBLUE, LRED, LORANGE, LGREEN, LBLUE2, LRED2, LORANGE2, LGREEN2, LD4, LD3, LD5, LD7, LD9, LD10, LD8, LD6 
	I2C_MAG_ADDR, ACC_CTRL_REG1_A_ODR_SHIFT, ACC_CTRL_REG1_A_ODR_MASK

 - Declare vars before first expression:
	Declare variables before the first expression (C89) in main().

 - Prototype functions before; define them after:
	Code is cleaner this way: first you see main and some functions it is going to use;  if you want to dig into these functions scroll down.

 - Move macros just after includes:
	That is the proper place to have macros defined: before any code that may use them.