### PR TITLE
Fix mainloop to not lose interrupts

### DIFF
--- a/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/syscfg.h
+++ b/examples/stm32/l1/stm32l-discovery/button-irq-printf-lowpower/syscfg.h
@@ -47,6 +47,7 @@ extern "C" {
 #define TIMER_BUTTON_PRESS_RST RST_TIM7
 
 	struct state_t {
+		bool interrupted;
 		bool falling;
 		bool pressed;
 		int rtc_ticked;


### PR DESCRIPTION
While looking for an example WRT interrupt handling and sleep, I found this -lowpower example. However, this example looks like it could lose an interrupt if it arrives while the main loop is *not* executing the `__WFI()` call.

In other words, there should be a `cm_disable_interrupts()` somewhere in there.

Granted that this is somewhat unlikely to happen with this particular example (release the button after _exactly_ one second …), but the rules are different in a real-world program. Thus I extended the example so that people won't copy incomplete code.