### PR TITLE
Nucleo-stm32f401re board example

### DIFF
--- a/examples/stm32/f4/nucleo-f401re/blink/Makefile
+++ b/examples/stm32/f4/nucleo-f401re/blink/Makefile
@@ -1,0 +1,25 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = blink
+
+LDSCRIPT = ../nucleo-f401re.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f4/nucleo-f401re/blink/README.md
+++ b/examples/stm32/f4/nucleo-f401re/blink/README.md
@@ -1,0 +1,10 @@
+# README
+
+This is the smallest-possible example program using libopencm3.
+
+It's intended for the ST Nucleo-F401RE eval board. It should blink
+the GREEN LED on the board.
+
+## Board connections
+
+*none required*

--- a/examples/stm32/f4/nucleo-f401re/blink/blink.c
+++ b/examples/stm32/f4/nucleo-f401re/blink/blink.c
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (c) 2015 Chuck McManis <cmcmanis@mcmanis.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+static void gpio_setup(void)
+{
+	/* Enable GPIOA clock. */
+	/* Manually: */
+	/*RCC_AHB1ENR |= RCC_AHB1ENR_IOPAEN; */
+	/* Using API functions: */
+	rcc_periph_clock_enable(RCC_GPIOA);
+
+	/* Set GPIO5 (in GPIO port A) to 'output push-pull'. */
+	/* Manually: */
+	/*GPIOA_CRH = (GPIO_CNF_OUTPUT_PUSHPULL << (((8 - 8) * 4) + 2)); */
+	/*GPIOA_CRH |= (GPIO_MODE_OUTPUT_2_MHZ << ((8 - 8) * 4)); */
+	/* Using API functions: */
+	gpio_mode_setup(GPIOA, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO5);
+}
+
+int main(void)
+{
+	int i;
+
+	gpio_setup();
+
+	/* Blink the LED (PC8) on the board. */
+	while (1) {
+		/* Manually: */
+		/* GPIOA_BSRR = GPIO5; */		/* LED off */
+		/* for (i = 0; i < 1000000; i++) */	/* Wait a bit. */
+		/*	__asm__("nop"); */
+		/* GPIOA_BRR = GPIO5; */		/* LED on */
+		/* for (i = 0; i < 1000000; i++) */	/* Wait a bit. */
+		/*	__asm__("nop"); */
+
+		/* Using API functions gpio_set()/gpio_clear(): */
+		/* gpio_set(GPIOA, GPIO5); */	/* LED off */
+		/* for (i = 0; i < 1000000; i++) */	/* Wait a bit. */
+		/*	__asm__("nop"); */
+		/* gpio_clear(GPIOA, GPIO5); */	/* LED on */
+		/* for (i = 0; i < 1000000; i++) */	/* Wait a bit. */
+		/*	__asm__("nop"); */
+
+		/* Using API function gpio_toggle(): */
+		gpio_toggle(GPIOA, GPIO5);	/* LED on/off */
+		for (i = 0; i < 1000000; i++) {	/* Wait a bit. */
+			__asm__("nop");
+		}
+	}
+
+	return 0;
+}

--- a/examples/stm32/f4/nucleo-f401re/nucleo-f401re.ld
+++ b/examples/stm32/f4/nucleo-f401re/nucleo-f401re.ld
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for Nucleo F401RE  (STM32F401RE, 512K flash, 128K RAM). */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 512K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 96K
+}
+
+/* Include the common ld script. */
+INCLUDE cortex-m-generic.ld
+

--- a/examples/stm32/f4/nucleo-f401re/pll_usart_irq/Makefile
+++ b/examples/stm32/f4/nucleo-f401re/pll_usart_irq/Makefile
@@ -1,0 +1,26 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+OBJS = clock.o console.o
+BINARY = pll_usart_irq
+
+LDSCRIPT = ../nucleo-f401re.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f4/nucleo-f401re/pll_usart_irq/README.md
+++ b/examples/stm32/f4/nucleo-f401re/pll_usart_irq/README.md
@@ -1,0 +1,6 @@
+# README
+
+Configures internal PLL to make internal bus run at 84MHz (maximum frequency allowed on stm32f401).  
+Toggles user led (LD2) on and off at 1Hz  
+Display "Console test program" message on serial console at 1Hz  
+

--- a/examples/stm32/f4/nucleo-f401re/pll_usart_irq/clock.c
+++ b/examples/stm32/f4/nucleo-f401re/pll_usart_irq/clock.c
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Chuck McManis <cmcmanis@mcmanis.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Now this is just the clock setup code from systick-blink as it is the
+ * transferrable part.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/cm3/systick.h>
+
+#include <libopencm3/stm32/gpio.h>
+
+/* Common function descriptions */
+#include "clock.h"
+
+/* milliseconds since boot */
+static volatile uint32_t system_millis;
+
+/* Called when systick fires */
+void sys_tick_handler(void)
+{
+	system_millis++;
+}
+
+/* simple sleep for delay milliseconds */
+void msleep(uint32_t delay)
+{
+	uint32_t wake = system_millis + delay;
+	while (wake > system_millis);
+}
+
+/* Getter function for the current time */
+uint32_t mtime(void)
+{
+	return system_millis;
+}
+
+/*
+ * clock_setup(void)
+ *
+ * This function sets up both the base board clock rate
+ * and a 1khz "system tick" count. The SYSTICK counter is
+ * a standard feature of the Cortex-M series.
+ */
+void clock_setup(void)
+{
+	/* Base board frequency, set to 84Mhz */
+	rcc_clock_setup_pll(&rcc_hsi_configs[RCC_CLOCK_3V3_84MHZ]);
+	gpio_toggle(GPIOA, GPIO5);
+
+	/* clock rate / 84000 to get 1mS interrupt rate */
+	systick_set_reload(84000);
+	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB);
+	systick_counter_enable();
+
+	/* this done last */
+	systick_interrupt_enable();
+}

--- a/examples/stm32/f4/nucleo-f401re/pll_usart_irq/clock.h
+++ b/examples/stm32/f4/nucleo-f401re/pll_usart_irq/clock.h
@@ -1,0 +1,16 @@
+/* vim: set noexpandtab ts=4 :
+ *
+ * This include file describes the functions exported by clock.c
+ */
+#ifndef __CLOCK_H
+#define __CLOCK_H
+
+/*
+ * Definitions for functions being abstracted out
+ */
+void msleep(uint32_t);
+uint32_t mtime(void);
+void clock_setup(void);
+
+#endif /* generic header protector */
+

--- a/examples/stm32/f4/nucleo-f401re/pll_usart_irq/console.c
+++ b/examples/stm32/f4/nucleo-f401re/pll_usart_irq/console.c
@@ -1,0 +1,227 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Chuck McManis <cmcmanis@mcmanis.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Interrupt drive Console code (extracted from the usart-irq example)
+ *
+ */
+
+#include <stdint.h>
+#include <setjmp.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/stm32/iwdg.h>
+#include <libopencm3/cm3/scb.h>
+#include <libopencm3/cm3/cortex.h>
+#include "clock.h"
+#include "console.h"
+
+
+/* This is a ring buffer to holding characters as they are typed
+ * it maintains both the place to put the next character received
+ * from the UART, and the place where the last character was
+ * read by the program. See the README file for a discussion of
+ * the failure semantics.
+ */
+#define RECV_BUF_SIZE	128		/* Arbitrary buffer size */
+char recv_buf[RECV_BUF_SIZE];
+volatile int recv_ndx_nxt;		/* Next place to store */
+volatile int recv_ndx_cur;		/* Next place to read */
+
+/* For interrupt handling we add a new function which is called
+ * when recieve interrupts happen. The name (usart2_isr) is created
+ * by the irq.json file in libopencm3 calling this interrupt for
+ * USART2 'usart2', adding the suffix '_isr', and then weakly binding
+ * it to the 'do nothing' interrupt function in vec.c.
+ *
+ * By defining it in this file the linker will override that weak
+ * binding and instead bind it here, but you have to get the name
+ * right or it won't work. And you'll wonder where your interrupts
+ * are going.
+ */
+void usart2_isr(void)
+{
+	uint32_t reg;
+	int i;
+
+	do {
+		reg = USART_SR(CONSOLE_UART);
+		if (reg & USART_SR_RXNE) {
+			recv_buf[recv_ndx_nxt] = USART_DR(CONSOLE_UART);
+#ifdef RESET_ON_CTRLC
+			/*
+			 * This bit of code will jump to the ResetHandler if you
+			 * hit ^C
+			 */
+			if (recv_buf[recv_ndx_nxt] == '\003') {
+				scb_reset_system();
+				return; /* never actually reached */
+			}
+#endif
+			/* Check for "overrun" */
+			i = (recv_ndx_nxt + 1) % RECV_BUF_SIZE;
+			if (i != recv_ndx_cur) {
+				recv_ndx_nxt = i;
+			}
+		}
+	} while ((reg & USART_SR_RXNE) != 0); /* can read back-to-back
+						 interrupts */
+}
+
+/*
+ * console_putc(char c)
+ *
+ * Send the character 'c' to the USART, wait for the USART
+ * transmit buffer to be empty first.
+ */
+void console_putc(char c)
+{
+	uint32_t	reg;
+	do {
+		reg = USART_SR(CONSOLE_UART);
+	} while ((reg & USART_SR_TXE) == 0);
+	USART_DR(CONSOLE_UART) = (uint16_t) c & 0xff;
+}
+
+/*
+ * char = console_getc(int wait)
+ *
+ * Check the console for a character. If the wait flag is
+ * non-zero. Continue checking until a character is received
+ * otherwise return 0 if called and no character was available.
+ *
+ * The implementation is a bit different however, now it looks
+ * in the ring buffer to see if a character has arrived.
+ */
+char console_getc(int wait)
+{
+	char		c = 0;
+
+	while ((wait != 0) && (recv_ndx_cur == recv_ndx_nxt));
+	if (recv_ndx_cur != recv_ndx_nxt) {
+		c = recv_buf[recv_ndx_cur];
+		recv_ndx_cur = (recv_ndx_cur + 1) % RECV_BUF_SIZE;
+	}
+	return c;
+}
+
+/*
+ * void console_puts(char *s)
+ *
+ * Send a string to the console, one character at a time, return
+ * after the last character, as indicated by a NUL character, is
+ * reached.
+ */
+void console_puts(char *s)
+{
+	while (*s != '\000') {
+		console_putc(*s);
+		/* Add in a carraige return, after sending line feed */
+		if (*s == '\n') {
+			console_putc('\r');
+		}
+		s++;
+	}
+}
+
+/*
+ * int console_gets(char *s, int len)
+ *
+ * Wait for a string to be entered on the console, limited
+ * support for editing characters (back space and delete)
+ * end when a <CR> character is received.
+ */
+int console_gets(char *s, int len)
+{
+	char *t = s;
+	char c;
+
+	*t = '\000';
+	/* read until a <CR> is received */
+	while ((c = console_getc(1)) != '\r') {
+		if ((c == '\010') || (c == '\127')) {
+			if (t > s) {
+				/* send ^H ^H to erase previous character */
+				console_puts("\010 \010");
+				t--;
+			}
+		} else {
+			*t = c;
+			console_putc(c);
+			if ((t - s) < len) {
+				t++;
+			}
+		}
+		/* update end of string with NUL */
+		*t = '\000';
+	}
+	return t - s;
+}
+
+/*
+ * console_setup(int baudrate)
+ *
+ * Set the pins and clocks to create a console that we can
+ * use for serial messages and getting text from the user.
+ */
+void console_setup(int baud)
+{
+	/* MUST enable the GPIO clock in ADDITION to the USART clock */
+	rcc_periph_clock_enable(RCC_GPIOA);
+
+	/* This example uses PA2 and PA3 for Tx and Rx respectively
+	 * but other pins are available for this role on USART2 (our chosen
+	 * USART) as well, we are using these because they are connected to the
+	 * programmer through some jumpers.
+	 */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2 | GPIO3);
+
+	/* Actual Alternate function number (in this case 7) is part
+	 * depenedent, CHECK THE DATA SHEET for the right number to
+	 * use.
+	 */
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2 | GPIO3);
+
+
+	/* This then enables the clock to the USART2 peripheral which is
+	 * attached inside the chip to the APB1 bus. Different peripherals
+	 * attach to different buses, and even some UARTS are attached to
+	 * APB1 and some to APB2, again the data sheet is useful here.
+	 * We are using rcc_periph_clock_enable that knows which peripheral is
+	 * on which clock bus and sets up everything accordingly.
+	 */
+	rcc_periph_clock_enable(RCC_USART2);
+
+	/* Set up USART/UART parameters using the libopencm3 helper functions */
+	usart_set_baudrate(CONSOLE_UART, baud);
+	usart_set_databits(CONSOLE_UART, 8);
+	usart_set_stopbits(CONSOLE_UART, USART_STOPBITS_1);
+	usart_set_mode(CONSOLE_UART, USART_MODE_TX_RX);
+	usart_set_parity(CONSOLE_UART, USART_PARITY_NONE);
+	usart_set_flow_control(CONSOLE_UART, USART_FLOWCONTROL_NONE);
+	usart_enable(CONSOLE_UART);
+
+	/* Enable interrupts from the USART */
+	nvic_enable_irq(NVIC_USART2_IRQ);
+
+	/* Specifically enable recieve interrupts */
+	usart_enable_rx_interrupt(CONSOLE_UART);
+}

--- a/examples/stm32/f4/nucleo-f401re/pll_usart_irq/console.h
+++ b/examples/stm32/f4/nucleo-f401re/pll_usart_irq/console.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2013 Chuck McManis <cmcmanis@mcmanis.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __CONSOLE_H
+#define __CONSOLE_H
+
+/*
+ * Some definitions of our console "functions" attached to the
+ * USART.
+ *
+ * These define sort of the minimum "library" of functions which
+ * we can use on a serial port. If you wish to use a different
+ * USART there are several things to change:
+ *	- CONSOLE_UART change this
+ *	- Change the peripheral enable clock
+ *	- add usartx_isr for interrupts
+ *	- nvic_enable_interrupt(your choice of USART/UART)
+ *	- GPIO pins for transmit/receive
+ *		(may be on different alternate functions as well)
+ */
+
+
+#define CONSOLE_UART	USART2
+
+/*
+ * Our simple console definitions
+ */
+
+void console_putc(char c);
+char console_getc(int wait);
+void console_puts(char *s);
+int console_gets(char *s, int len);
+void console_setup(int baudrate);
+
+/* this is for fun, if you type ^C to this example it will reset */
+#define RESET_ON_CTRLC
+
+#endif

--- a/examples/stm32/f4/nucleo-f401re/pll_usart_irq/pll_usart_irq.c
+++ b/examples/stm32/f4/nucleo-f401re/pll_usart_irq/pll_usart_irq.c
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (c) 2015 Chuck McManis <cmcmanis@mcmanis.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+#include "clock.h"
+#include "console.h"
+
+static void gpio_clock_setup(void)
+{
+	/* Enable GPIOA clock for LED & USARTs. */
+	rcc_periph_clock_enable(RCC_GPIOA);
+}
+
+static void gpio_setup(void)
+{
+
+	/* Set GPIO5 (in GPIO port A) to 'output push-pull'. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO5);
+
+}
+
+int main(void)
+{
+	gpio_clock_setup();
+	gpio_setup();
+	clock_setup();
+	console_setup(115200);
+
+	/* Blink the LED on the board and print message. */
+	while (1) {
+		/* Using API function gpio_toggle(): */
+		gpio_toggle(GPIOA, GPIO5);	/* LED on/off */
+		console_puts("Console test program\n");
+		msleep(500);
+	}
+
+	return 0;
+}
+


### PR DESCRIPTION
Added the following examples for nucleo-stm32f401re board:
- blink
- pll_usart_irq (configures pll, and send message on USART2 at 1Hz)