### PR TITLE
Add make rule for flashing with ST-LINK: stflash

### DIFF
--- a/examples/rules.mk
+++ b/examples/rules.mk
@@ -156,6 +156,7 @@ GENERATED_BINARIES=$(BINARY).elf $(BINARY).bin $(BINARY).hex $(BINARY).srec $(BI
 
 images: $(BINARY).images
 flash: $(BINARY).flash
+stflash: $(BINARY).stlink-flash
 
 # Either verify the user provided LDSCRIPT exists, or generate it.
 ifeq ($(strip $(DEVICE)),)


### PR DESCRIPTION
I noticed that there was a make rule of `%.stlink-flash` but nothing
called that particular code path. This adds a rule of `stflash` that
flashes the binary with ST-LINK.

Please note that I am not really familiar with Makefiles. This is what
I had to do to get this working after looking through the file. Please
let me know if there is a better name than `stflash` or if there are
other ways to make this better.