### PR TITLE
f1: adc_inj - remove the code which clears EOC flag.

### DIFF
--- a/examples/stm32/f1/lisa-m-2/adc_injec/adc_injec.c
+++ b/examples/stm32/f1/lisa-m-2/adc_injec/adc_injec.c
@@ -154,7 +154,6 @@ int main(void)
 
 		/* Wait for end of conversion. */
 		while (!(adc_eoc_injected(ADC1)));
-		ADC_SR(ADC2) &= ~ADC_SR_JEOC; //clear injected end of conversion
 
 		temperature = adc_read_injected(ADC1,1); //get the result from ADC_JDR1 on ADC1 (only bottom 16bits)
 


### PR DESCRIPTION
According to DS, the EOC flag is reset by the next trigger
In this example, we are already calling adc_start_conversion_injected()
which resets the EOC flag.

Signed-off-by: Amitesh Singh <singh.amitesh@gmail.com>