### PR TITLE
Incorrect GPIO config F4 USART example

### DIFF
--- a/examples/stm32/f4/stm32f4-discovery/usart/usart.c
+++ b/examples/stm32/f4/stm32f4-discovery/usart/usart.c
@@ -49,7 +49,7 @@ static void usart_setup(void)
 static void gpio_setup(void)
 {
 	/* Setup GPIO pin GPIO12 on GPIO port D for LED. */
-	gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO12);
+	gpio_mode_setup(GPIOD, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO12);
 
 	/* Setup GPIO pins for USART2 transmit. */
 	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2);


### PR DESCRIPTION
Did not get this example to work, it worked after changing `GPIO_MODE_OUTPUT` to `GPIO_MODE_AF`