### PR TITLE
stm32: cdcacm: fix array out of bounds write

### DIFF
--- a/examples/stm32/f1/lisa-m-1/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/lisa-m-1/usb_cdcacm/cdcacm.c
@@ -213,7 +213,6 @@ static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)
 	if (len) {
 		while (usbd_ep_write_packet(usbd_dev, 0x82, buf, len) == 0)
 			;
-		buf[len] = 0;
 	}
 
 	gpio_toggle(GPIOC, GPIO5);

--- a/examples/stm32/f1/other/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/other/usb_cdcacm/cdcacm.c
@@ -212,7 +212,6 @@ static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)
 
 	if (len) {
 		usbd_ep_write_packet(usbd_dev, 0x82, buf, len);
-		buf[len] = 0;
 	}
 }
 

--- a/examples/stm32/f1/stm32-h103/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/stm32-h103/usb_cdcacm/cdcacm.c
@@ -212,7 +212,6 @@ static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)
 
 	if (len) {
 		usbd_ep_write_packet(usbd_dev, 0x82, buf, len);
-		buf[len] = 0;
 	}
 }
 

--- a/examples/stm32/f1/stm32-maple/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f1/stm32-maple/usb_cdcacm/cdcacm.c
@@ -213,7 +213,6 @@ static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)
 
 	if (len) {
 		usbd_ep_write_packet(usbd_dev, 0x82, buf, len);
-		buf[len] = 0;
 	}
 }
 

--- a/examples/stm32/f1/waveshare-open103r/usbserial/usbserial.c
+++ b/examples/stm32/f1/waveshare-open103r/usbserial/usbserial.c
@@ -224,7 +224,6 @@ static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)
 
   if (len) {
     usbd_ep_write_packet(usbd_dev, 0x82, buf, len);
-    buf[len] = 0;
   }
 }
 

--- a/examples/stm32/f3/stm32f3-discovery/usb_cdcacm/cdcacm.c
+++ b/examples/stm32/f3/stm32f3-discovery/usb_cdcacm/cdcacm.c
@@ -212,7 +212,6 @@ static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep)
 
 	if (len) {
 		usbd_ep_write_packet(usbd_dev, 0x82, buf, len);
-		buf[len] = 0;
 	}
 }
 


### PR DESCRIPTION
Remove unused code that is also an out of bounds write causing
memory corruption.