### PR TITLE
stm32f429i-discovery: fix detection of ASCII DEL character

### DIFF
--- a/examples/stm32/f4/stm32f429i-discovery/lcd-dma/console.c
+++ b/examples/stm32/f4/stm32f429i-discovery/lcd-dma/console.c
@@ -155,7 +155,7 @@ int console_gets(char *s, int len)
 	*t = '\000';
 	/* read until a <CR> is received */
 	while ((c = console_getc(1)) != '\r') {
-		if ((c == '\010') || (c == '\127')) {
+		if ((c == '\010') || (c == '\177')) {
 			if (t > s) {
 				/* send ^H ^H to erase previous character */
 				console_puts("\010 \010");

--- a/examples/stm32/f4/stm32f429i-discovery/lcd-serial/console.c
+++ b/examples/stm32/f4/stm32f429i-discovery/lcd-serial/console.c
@@ -157,7 +157,7 @@ int console_gets(char *s, int len)
 	*t = '\000';
 	/* read until a <CR> is received */
 	while ((c = console_getc(1)) != '\r') {
-		if ((c == '\010') || (c == '\127')) {
+		if ((c == '\010') || (c == '\177')) {
 			if (t > s) {
 				/* send ^H ^H to erase previous character */
 				console_puts("\010 \010");

--- a/examples/stm32/f4/stm32f429i-discovery/sdram/console.c
+++ b/examples/stm32/f4/stm32f429i-discovery/sdram/console.c
@@ -169,7 +169,7 @@ int console_gets(char *s, int len)
 	*t = '\000';
 	/* read until a <CR> is received */
 	while ((c = console_getc(1)) != '\r') {
-		if ((c == '\010') || (c == '\127')) {
+		if ((c == '\010') || (c == '\177')) {
 			if (t > s) {
 				/* send ^H ^H to erase previous character */
 				console_puts("\010 \010");

--- a/examples/stm32/f4/stm32f429i-discovery/spi/console.c
+++ b/examples/stm32/f4/stm32f429i-discovery/spi/console.c
@@ -157,7 +157,7 @@ int console_gets(char *s, int len)
 	*t = '\000';
 	/* read until a <CR> is received */
 	while ((c = console_getc(1)) != '\r') {
-		if ((c == '\010') || (c == '\127')) {
+		if ((c == '\010') || (c == '\177')) {
 			if (t > s) {
 				/* send ^H ^H to erase previous character */
 				console_puts("\010 \010");

--- a/examples/stm32/f4/stm32f429i-discovery/usart_console/usart_console.c
+++ b/examples/stm32/f4/stm32f429i-discovery/usart_console/usart_console.c
@@ -107,7 +107,7 @@ int console_gets(char *s, int len)
 	*t = '\000';
 	/* read until a <CR> is received */
 	while ((c = console_getc(1)) != '\r') {
-		if ((c == '\010') || (c == '\127')) {
+		if ((c == '\010') || (c == '\177')) {
 			if (t > s) {
 				/* send ^H ^H to erase previous character */
 				console_puts("\010 \010");

--- a/examples/stm32/f4/stm32f429i-discovery/usart_irq_console/usart_irq_console.c
+++ b/examples/stm32/f4/stm32f429i-discovery/usart_irq_console/usart_irq_console.c
@@ -221,7 +221,7 @@ int console_gets(char *s, int len)
 	*t = '\000';
 	/* read until a <CR> is received */
 	while ((c = console_getc(1)) != '\r') {
-		if ((c == '\010') || (c == '\127')) {
+		if ((c == '\010') || (c == '\177')) {
 			if (t > s) {
 				/* send ^H ^H to erase previous character */
 				console_puts("\010 \010");


### PR DESCRIPTION
This code tries to match a Backspace character (hex 08, octal 010) or a Delete character (hex 7F, octal 177), but the octal number for the latter was incorrect and it was detecting a 'W' instead.

Thanks!