### PR TITLE
Blue pill simple examples

### DIFF
--- a/examples/stm32/f1/blue-pill/fancyblink/Makefile
+++ b/examples/stm32/f1/blue-pill/fancyblink/Makefile
@@ -1,0 +1,25 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = fancyblink
+
+LDSCRIPT = ../stm32-blue-pill.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f1/blue-pill/fancyblink/README.md
+++ b/examples/stm32/f1/blue-pill/fancyblink/README.md
@@ -1,0 +1,9 @@
+# README
+
+This is small LED blinking example program using libopencm3.
+
+It's intended for the ST STM32-based Blue Pill board
+https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill
+
+It should blink the LED on the board faster than the miniblink example.
+

--- a/examples/stm32/f1/blue-pill/fancyblink/fancyblink.c
+++ b/examples/stm32/f1/blue-pill/fancyblink/fancyblink.c
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+/* Set STM32 to 72 MHz. */
+static void clock_setup(void)
+{
+	rcc_clock_setup_pll(&rcc_hse_configs[RCC_CLOCK_HSE8_72MHZ]);
+
+	/* Enable GPIOC clock. */
+	rcc_periph_clock_enable(RCC_GPIOC);
+}
+
+static void gpio_setup(void)
+{
+	/* Set GPIO13 (in GPIO port C) to 'output push-pull'. */
+	gpio_set_mode(GPIOC, GPIO_MODE_OUTPUT_50_MHZ,
+		      GPIO_CNF_OUTPUT_PUSHPULL, GPIO13);
+}
+
+int main(void)
+{
+	int i;
+
+	clock_setup();
+	gpio_setup();
+
+	/* Blink the LED (PC13) on the board. */
+	while (1) {
+		gpio_toggle(GPIOC, GPIO13);	/* LED on/off */
+		for (i = 0; i < 800000; i++)	/* Wait a bit. */
+			__asm__("nop");
+	}
+
+	return 0;
+}

--- a/examples/stm32/f1/blue-pill/miniblink/Makefile
+++ b/examples/stm32/f1/blue-pill/miniblink/Makefile
@@ -1,0 +1,25 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = miniblink
+
+LDSCRIPT = ../stm32-blue-pill.ld
+
+include ../../Makefile.include
+

--- a/examples/stm32/f1/blue-pill/miniblink/README.md
+++ b/examples/stm32/f1/blue-pill/miniblink/README.md
@@ -1,0 +1,8 @@
+# README
+
+This is the smallest-possible example program using libopencm3.
+
+It's intended for the ST STM32-based
+[Olimex STM32-H103 eval board](http://olimex.com/dev/stm32-h103.html).
+It should blink the LED on the board.
+

--- a/examples/stm32/f1/blue-pill/miniblink/miniblink.c
+++ b/examples/stm32/f1/blue-pill/miniblink/miniblink.c
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+static void gpio_setup(void)
+{
+	/* Enable GPIOC clock. */
+	/* Manually: */
+	// RCC_APB2ENR |= RCC_APB2ENR_IOPCEN;
+	/* Using API functions: */
+	rcc_periph_clock_enable(RCC_GPIOC);
+
+	/* Set GPIO13 (in GPIO port C) to 'output push-pull'. */
+	/* Manually: */
+	// GPIOC_CRH = (GPIO_CNF_OUTPUT_PUSHPULL << (((13 - 8) * 4) + 2));
+	// GPIOC_CRH |= (GPIO_MODE_OUTPUT_2_MHZ << ((13 - 8) * 4));
+	/* Using API functions: */
+	gpio_set_mode(GPIOC, GPIO_MODE_OUTPUT_2_MHZ,
+		      GPIO_CNF_OUTPUT_PUSHPULL, GPIO13);
+}
+
+int main(void)
+{
+	int i;
+
+	gpio_setup();
+
+	/* Blink the LED (PC13) on the board. */
+	while (1) {
+		/* Manually: */
+		// GPIOC_BSRR = GPIO13;		/* LED off */
+		// for (i = 0; i < 800000; i++)	/* Wait a bit. */
+		// 	__asm__("nop");
+		// GPIOC_BRR = GPIO13;		/* LED on */
+		// for (i = 0; i < 800000; i++)	/* Wait a bit. */
+		// 	__asm__("nop");
+
+		/* Using API functions gpio_set()/gpio_clear(): */
+		// gpio_set(GPIOC, GPIO13);	/* LED off */
+		// for (i = 0; i < 800000; i++)	/* Wait a bit. */
+		// 	__asm__("nop");
+		// gpio_clear(GPIOC, GPIO13);	/* LED on */
+		// for (i = 0; i < 800000; i++)	/* Wait a bit. */
+		// 	__asm__("nop");
+
+		/* Using API function gpio_toggle(): */
+		gpio_toggle(GPIOC, GPIO13);	/* LED on/off */
+		for (i = 0; i < 800000; i++)	/* Wait a bit. */
+			__asm__("nop");
+	}
+
+	return 0;
+}

--- a/examples/stm32/f1/blue-pill/stm32-blue-pill.ld
+++ b/examples/stm32/f1/blue-pill/stm32-blue-pill.ld
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for STM32 Blue Pill (STM32F103C8T6, 64K flash, 20K RAM). */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 64K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
+}
+
+/* Include the common ld script. */
+INCLUDE cortex-m-generic.ld
+


### PR DESCRIPTION
miniblink and fancyblink for Blue Pill

https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill

These boards are STM32duino examples. They are extremely cheap and are getting very popular. Flashed with a cheap stlink-v2 swd clone programmer.

These examples are taken from stm32-h103 and slightly modified (only the LED pin, and the flash size is changed).