### PR TITLE
Update README.md with J-Link flashing method

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ This example uses the st-util by texane that you can find on [GitHub](https://gi
     load
     run
 
+### Objcopy (arm-none-eabi-objcopy) + JLink
+
+Create .bin file using:
+
+    cd examples/stm32/f1/stm32vl-discovery/miniblink
+    make
+    arm-none-eabi-objcopy -O binary miniblink.elf miniblink.bin
+    
+This will give you a binary that can be flashed through any means, such as J-Link:
+
+    loadfile miniblink.bin
+
 ## Reuse
 
 If you want to use libopencm3 in your own project, the _easiest_ way is


### PR DESCRIPTION
Added new method of flashing code to target using arm-none-eabi-objcopy to make a binary file and J-Link to upload the binary.