### PR TITLE
Add STM32F411CEU6 Black Pill board examples 

### DIFF
--- a/examples/stm32/f4/blackpill-f411ceu6/README.md
+++ b/examples/stm32/f4/blackpill-f411ceu6/README.md
@@ -1,0 +1,34 @@
+# WeAct Studio Black Pill (STM32F411CEU6)
+
+This directory contains libopencm3 examples for the WeAct Studio "Black
+Pill" development board, built around the STM32F411CEU6 (Cortex-M4,
+512K flash, 128K RAM).
+
+## Board details
+
+- MCU: STM32F411CEU6
+- External crystal (HSE): 25 MHz
+- Onboard LED: PC13 (active-low — pin LOW turns the LED on)
+- Onboard user button: PA0
+- USB: DFU-capable ROM bootloader (BOOT0 pin), also usable for
+  flashing without an external programmer
+
+## Flashing
+
+Via ST-Link/OpenOCD:
+
+```
+cd blink
+make
+make flash
+```
+
+Via DFU (no ST-Link required — hold BOOT0, tap RESET, release BOOT0):
+
+```
+dfu-util -a 0 -s 0x08000000:leave -D blink.bin
+```
+
+## Examples
+
+- `blink/` — toggles the onboard PC13 LED using `gpio_toggle()`.

--- a/examples/stm32/f4/blackpill-f411ceu6/README.md
+++ b/examples/stm32/f4/blackpill-f411ceu6/README.md
@@ -32,3 +32,7 @@ dfu-util -a 0 -s 0x08000000:leave -D blink.bin
 ## Examples
 
 - `blink/` — toggles the onboard PC13 LED using `gpio_toggle()`.
+- `usart/` — transmits a repeating digit sequence over USART2 (PA2, TX
+  only) at 115200 8N1, toggling the onboard PC13 LED with every byte
+  sent. Connect a USB-serial adapter's RX line to PA2 to view the
+  output.

--- a/examples/stm32/f4/blackpill-f411ceu6/blackpill-f411ceu6.ld
+++ b/examples/stm32/f4/blackpill-f411ceu6/blackpill-f411ceu6.ld
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for WeAct Studio Black Pill (STM32F411CEU6, 512K flash, 128K RAM). */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 512K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* Include the common ld script. */
+INCLUDE cortex-m-generic.ld

--- a/examples/stm32/f4/blackpill-f411ceu6/blink/Makefile
+++ b/examples/stm32/f4/blackpill-f411ceu6/blink/Makefile
@@ -1,0 +1,24 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = blink
+
+LDSCRIPT = ../blackpill-f411ceu6.ld
+
+include ../../Makefile.include

--- a/examples/stm32/f4/blackpill-f411ceu6/blink/blink.c
+++ b/examples/stm32/f4/blackpill-f411ceu6/blink/blink.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (c) 2015 Chuck McManis <cmcmanis@mcmanis.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Blink example for the WeAct Studio "Black Pill" board (STM32F411CEU6).
+ *
+ * The onboard LED is connected to PC13 and is active-low: writing the
+ * pin LOW turns the LED ON, writing it HIGH turns the LED OFF.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+static void gpio_setup(void)
+{
+	/* Enable GPIOC clock (onboard LED is on PC13). */
+	rcc_periph_clock_enable(RCC_GPIOC);
+
+	/* Set GPIO13 (in GPIO port C) to 'output push-pull'. */
+	gpio_mode_setup(GPIOC, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO13);
+}
+
+int main(void)
+{
+	int i;
+
+	gpio_setup();
+
+	while (1) {
+		/* LED is active-low: toggle it on/off. */
+		gpio_toggle(GPIOC, GPIO13);
+		for (i = 0; i < 2000000; i++) {	/* Wait a bit. */
+			__asm__("nop");
+		}
+	}
+
+	return 0;
+}

--- a/examples/stm32/f4/blackpill-f411ceu6/usart/Makefile
+++ b/examples/stm32/f4/blackpill-f411ceu6/usart/Makefile
@@ -1,0 +1,24 @@
+##
+## This file is part of the libopencm3 project.
+##
+## Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+##
+## This library is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with this library.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+BINARY = usart
+
+LDSCRIPT = ../blackpill-f411ceu6.ld
+
+include ../../Makefile.include

--- a/examples/stm32/f4/blackpill-f411ceu6/usart/usart.c
+++ b/examples/stm32/f4/blackpill-f411ceu6/usart/usart.c
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (C) 2015 Chuck McManis <cmcmanis@mcmanis.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * USART2 transmit example for the WeAct Studio "Black Pill" board
+ * (STM32F411CEU6).
+ *
+ * USART2 TX is broken out on PA2. Connect a USB-serial adapter's RX
+ * line to PA2 (and GND to GND) to view the output at 115200 8N1.
+ * The onboard LED (PC13, active-low) toggles with every byte sent.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/usart.h>
+
+static void clock_setup(void)
+{
+	/* Enable GPIOA clock (USART2 TX pin) and GPIOC clock (onboard LED). */
+	rcc_periph_clock_enable(RCC_GPIOA);
+	rcc_periph_clock_enable(RCC_GPIOC);
+
+	/* Enable clock for USART2. */
+	rcc_periph_clock_enable(RCC_USART2);
+}
+
+static void usart_setup(void)
+{
+	/* Setup USART2 parameters. */
+	usart_set_baudrate(USART2, 115200);
+	usart_set_databits(USART2, 8);
+	usart_set_stopbits(USART2, USART_STOPBITS_1);
+	usart_set_mode(USART2, USART_MODE_TX);
+	usart_set_parity(USART2, USART_PARITY_NONE);
+	usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
+
+	/* Finally enable the USART. */
+	usart_enable(USART2);
+}
+
+static void gpio_setup(void)
+{
+	/* Setup the onboard LED (PC13) as output. */
+	gpio_mode_setup(GPIOC, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO13);
+
+	/* Setup GPIO pin PA2 for USART2 transmit, alternate function. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2);
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2);
+}
+
+int main(void)
+{
+	int i, j = 0, c = 0;
+
+	clock_setup();
+	gpio_setup();
+	usart_setup();
+
+	/* Toggle the onboard LED (PC13) with every transmitted byte. */
+	while (1) {
+		gpio_toggle(GPIOC, GPIO13);		/* LED on/off */
+		usart_send_blocking(USART2, c + '0');	/* USART2: Send byte. */
+		c = (c == 9) ? 0 : c + 1;		/* Increment c. */
+		if ((j++ % 80) == 0) {			/* Newline after line full. */
+			usart_send_blocking(USART2, '\r');
+			usart_send_blocking(USART2, '\n');
+		}
+		for (i = 0; i < 300000; i++) {		/* Wait a bit. */
+			__asm__("NOP");
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This board (WeAct Studio Black Pill, STM32F411CEU6) wasn't previously
represented in the examples tree, only similar Nucleo boards. Added a
blink example targeting the onboard PC13 LED.

Built and tested on real hardware — confirmed LED blinks as expected.